### PR TITLE
Add invite URL paramter to user invite function

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ Alternatively, it is also possible to replace an existing active password with a
 ```java
 // Replaces the user's current password with a new one
 try {
-    ps.replaceUserPassword(loginId, oldPassword, newPassword);
+    AuthenticationInfo info = ps.replaceUserPassword(loginId, oldPassword, newPassword);
 } catch (DescopeException de) {
     // Handle the error
 }
@@ -662,10 +662,11 @@ try {
 }
 
 // Alternatively, a user can be created and invited via an email message.
-// Make sure to configure the invite URL in the Descope console prior to using this function,
+// You can configure the invite URL in the Descope console prior to using this function, or pass inviteUrl in the options parameter.
 // and that an email address is provided in the information.
 try {
-    us.invite("desmond@descope.com", UserRequest.builder()
+    us.invite("desmond@descope.com",
+						UserRequest.builder()
             .email("desmond@descope.com")
             .displayName("Desmond Copeland")
             .tenants(Arrays.asList(
@@ -673,7 +674,10 @@ try {
                     .tenantId("tenant-ID1")
                     .roleNames(Arrays.asList("role-name1"),
                 AssociatedTenant.builder()
-                    .tenantId("tenant-ID2")))));
+                    .tenantId("tenant-ID2")))),
+						InviteOptions.builder()
+						.inviteUrl("https://my-app.com/invite")
+					);
 } catch (DescopeException de) {
     // Handle the error
 }

--- a/src/main/java/com/descope/model/auth/InviteOptions.java
+++ b/src/main/java/com/descope/model/auth/InviteOptions.java
@@ -1,0 +1,14 @@
+package com.descope.model.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InviteOptions {
+  private String inviteUrl;
+}

--- a/src/main/java/com/descope/model/user/request/UserRequest.java
+++ b/src/main/java/com/descope/model/user/request/UserRequest.java
@@ -1,6 +1,7 @@
 package com.descope.model.user.request;
 
 import com.descope.model.auth.AssociatedTenant;
+
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -25,4 +26,5 @@ public class UserRequest {
   String picture;
   Boolean invite;
   Boolean test;
+  String inviteUrl;
 }

--- a/src/main/java/com/descope/model/user/request/UserRequest.java
+++ b/src/main/java/com/descope/model/user/request/UserRequest.java
@@ -1,7 +1,6 @@
 package com.descope.model.user.request;
 
 import com.descope.model.auth.AssociatedTenant;
-
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/descope/sdk/auth/PasswordService.java
+++ b/src/main/java/com/descope/sdk/auth/PasswordService.java
@@ -16,7 +16,7 @@ public interface PasswordService {
   void updateUserPassword(String loginId, String newPassword, String refreshToken)
       throws DescopeException;
 
-  void replaceUserPassword(String loginId, String oldPassword, String newPassword)
+  AuthenticationInfo replaceUserPassword(String loginId, String oldPassword, String newPassword)
       throws DescopeException;
 
   PasswordPolicy getPasswordPolicy() throws DescopeException;

--- a/src/main/java/com/descope/sdk/auth/impl/PasswordServiceImpl.java
+++ b/src/main/java/com/descope/sdk/auth/impl/PasswordServiceImpl.java
@@ -100,7 +100,7 @@ class PasswordServiceImpl extends AuthenticationServiceImpl implements PasswordS
   }
 
   @Override
-  public void replaceUserPassword(String loginId, String oldPassword, String newPassword)
+  public AuthenticationInfo replaceUserPassword(String loginId, String oldPassword, String newPassword)
       throws DescopeException {
     if (StringUtils.isBlank(loginId)) {
       throw ServerCommonException.invalidArgument("Login ID");
@@ -112,7 +112,8 @@ class PasswordServiceImpl extends AuthenticationServiceImpl implements PasswordS
             .newPassword(newPassword)
             .build();
     var apiProxy = getApiProxy();
-    apiProxy.post(getUri(REPLACE_USER_PASSWORD_LINK), pwdUpdateRequest, Void.class);
+    var jwtResponse = apiProxy.post(getUri(REPLACE_USER_PASSWORD_LINK), pwdUpdateRequest, JWTResponse.class);
+    return getAuthenticationInfo(jwtResponse);
   }
 
   @Override

--- a/src/main/java/com/descope/sdk/mgmt/UserService.java
+++ b/src/main/java/com/descope/sdk/mgmt/UserService.java
@@ -56,7 +56,7 @@ public interface UserService {
    *     make sure the login id is unique for test.
    * @param request request is optional, and if provided, all attributes within it are optional.
    * @param options Additional options for the invitation, such as invite URL.
-	 * @return {@link UserResponseDetails UserResponseDetails}
+   * @return {@link UserResponseDetails UserResponseDetails}
    * @throws DescopeException If there occurs any exception, a subtype of this exception will be
    *     thrown.
    */

--- a/src/main/java/com/descope/sdk/mgmt/UserService.java
+++ b/src/main/java/com/descope/sdk/mgmt/UserService.java
@@ -2,6 +2,7 @@ package com.descope.sdk.mgmt;
 
 import com.descope.enums.DeliveryMethod;
 import com.descope.exception.DescopeException;
+import com.descope.model.auth.InviteOptions;
 import com.descope.model.user.request.UserRequest;
 import com.descope.model.user.request.UserSearchRequest;
 import com.descope.model.user.response.AllUsersResponseDetails;
@@ -54,11 +55,12 @@ public interface UserService {
    * @param loginId The loginID is required and will determine what the user will use to sign in,
    *     make sure the login id is unique for test.
    * @param request request is optional, and if provided, all attributes within it are optional.
-   * @return {@link UserResponseDetails UserResponseDetails}
+   * @param options Additional options for the invitation, such as invite URL.
+	 * @return {@link UserResponseDetails UserResponseDetails}
    * @throws DescopeException If there occurs any exception, a subtype of this exception will be
    *     thrown.
    */
-  UserResponseDetails invite(String loginId, UserRequest request) throws DescopeException;
+  UserResponseDetails invite(String loginId, UserRequest request, InviteOptions options) throws DescopeException;
 
   /**
    * Update an existing user.

--- a/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
@@ -26,6 +26,7 @@ import static com.descope.literals.Routes.ManagementEndPoints.USER_UPDATE_STATUS
 import com.descope.enums.DeliveryMethod;
 import com.descope.exception.DescopeException;
 import com.descope.exception.ServerCommonException;
+import com.descope.model.auth.InviteOptions;
 import com.descope.model.client.Client;
 import com.descope.model.mgmt.ManagementParams;
 import com.descope.model.user.request.EnchantedLinkTestUserRequest;
@@ -58,6 +59,7 @@ class UserServiceImpl extends ManagementsBase implements UserService {
       request = new UserRequest();
     }
     request.setLoginId(loginId);
+    request.setInviteUrl("");
     request.setInvite(false);
     request.setTest(false);
 
@@ -75,6 +77,7 @@ class UserServiceImpl extends ManagementsBase implements UserService {
 
     request.setLoginId(loginId);
     request.setInvite(false);
+    request.setInviteUrl("");
     request.setTest(true);
 
     URI createUserUri = composeCreateUserUri();
@@ -83,7 +86,8 @@ class UserServiceImpl extends ManagementsBase implements UserService {
   }
 
   @Override
-  public UserResponseDetails invite(String loginId, UserRequest request) throws DescopeException {
+  public UserResponseDetails invite(String loginId, UserRequest request, InviteOptions options)
+      throws DescopeException {
     if (request == null) {
       request = new UserRequest();
     }
@@ -91,6 +95,10 @@ class UserServiceImpl extends ManagementsBase implements UserService {
     request.setLoginId(loginId);
     request.setInvite(true);
     request.setTest(false);
+
+    if (options != null) {
+      request.setInviteUrl(options.getInviteUrl());
+		}
 
     URI createUserUri = composeCreateUserUri();
     var apiProxy = getApiProxy();

--- a/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
@@ -98,7 +98,7 @@ class UserServiceImpl extends ManagementsBase implements UserService {
 
     if (options != null) {
       request.setInviteUrl(options.getInviteUrl());
-		}
+    }
 
     URI createUserUri = composeCreateUserUri();
     var apiProxy = getApiProxy();

--- a/src/test/java/com/descope/sdk/auth/impl/PasswordServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/auth/impl/PasswordServiceImplTest.java
@@ -190,12 +190,19 @@ public class PasswordServiceImplTest {
   @Test
   void testReplaceUserPasswordForSuccess() {
     var apiProxy = mock(ApiProxy.class);
-    doReturn(Void.class).when(apiProxy).post(any(), any(), any());
-    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+    doReturn(MOCK_JWT_RESPONSE).when(apiProxy).post(any(), any(), any());
+		doReturn(new SigningKeysResponse(List.of(MOCK_SIGNING_KEY)))
+      .when(apiProxy).get(any(), eq(SigningKeysResponse.class));
+
+		try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
       mockedApiProxyBuilder.when(
         () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
-      passwordService.replaceUserPassword(MOCK_EMAIL, MOCK_PWD, MOCK_PWD);
-      verify(apiProxy, times(1)).post(any(), any(), any());
+      try (MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+        mockedJwtUtils.when(() -> JwtUtils.getToken(anyString(), any())).thenReturn(MOCK_TOKEN);
+       	var authenticationInfo = passwordService.replaceUserPassword(MOCK_EMAIL, MOCK_PWD, MOCK_PWD);
+				Assertions.assertThat(authenticationInfo).isNotNull();
+      	verify(apiProxy, times(1)).post(any(), any(), any());
+      }
     }
   }
 
@@ -280,7 +287,8 @@ public class PasswordServiceImplTest {
     user = authInfo.getUser();
     assertNotNull(user);
     assertFalse(authInfo.getFirstSeen());
-    passwordService.replaceUserPassword(loginId, MOCK_PWD, MOCK_PWD + "1");
+    authInfo = passwordService.replaceUserPassword(loginId, MOCK_PWD, MOCK_PWD + "1");
+		assertThat(authInfo.getRefreshToken().getJwt()).isNotBlank();
     authInfo = passwordService.signIn(loginId, MOCK_PWD + "1");
     assertThat(authInfo.getRefreshToken().getJwt()).isNotBlank();
     passwordService.updateUserPassword(

--- a/src/test/java/com/descope/sdk/auth/impl/PasswordServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/auth/impl/PasswordServiceImplTest.java
@@ -191,17 +191,17 @@ public class PasswordServiceImplTest {
   void testReplaceUserPasswordForSuccess() {
     var apiProxy = mock(ApiProxy.class);
     doReturn(MOCK_JWT_RESPONSE).when(apiProxy).post(any(), any(), any());
-		doReturn(new SigningKeysResponse(List.of(MOCK_SIGNING_KEY)))
+    doReturn(new SigningKeysResponse(List.of(MOCK_SIGNING_KEY)))
       .when(apiProxy).get(any(), eq(SigningKeysResponse.class));
 
-		try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
       mockedApiProxyBuilder.when(
         () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
       try (MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
         mockedJwtUtils.when(() -> JwtUtils.getToken(anyString(), any())).thenReturn(MOCK_TOKEN);
-       	var authenticationInfo = passwordService.replaceUserPassword(MOCK_EMAIL, MOCK_PWD, MOCK_PWD);
-				Assertions.assertThat(authenticationInfo).isNotNull();
-      	verify(apiProxy, times(1)).post(any(), any(), any());
+        var authenticationInfo = passwordService.replaceUserPassword(MOCK_EMAIL, MOCK_PWD, MOCK_PWD);
+        Assertions.assertThat(authenticationInfo).isNotNull();
+        verify(apiProxy, times(1)).post(any(), any(), any());
       }
     }
   }
@@ -288,7 +288,7 @@ public class PasswordServiceImplTest {
     assertNotNull(user);
     assertFalse(authInfo.getFirstSeen());
     authInfo = passwordService.replaceUserPassword(loginId, MOCK_PWD, MOCK_PWD + "1");
-		assertThat(authInfo.getRefreshToken().getJwt()).isNotBlank();
+    assertThat(authInfo.getRefreshToken().getJwt()).isNotBlank();
     authInfo = passwordService.signIn(loginId, MOCK_PWD + "1");
     assertThat(authInfo.getRefreshToken().getJwt()).isNotBlank();
     passwordService.updateUserPassword(

--- a/src/test/java/com/descope/sdk/mgmt/impl/UserServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/UserServiceImplTest.java
@@ -16,6 +16,7 @@ import com.descope.enums.DeliveryMethod;
 import com.descope.exception.RateLimitExceededException;
 import com.descope.exception.ServerCommonException;
 import com.descope.model.auth.AssociatedTenant;
+import com.descope.model.auth.InviteOptions;
 import com.descope.model.user.request.UserRequest;
 import com.descope.model.user.request.UserSearchRequest;
 import com.descope.model.user.response.AllUsersResponseDetails;
@@ -96,11 +97,13 @@ public class UserServiceImplTest {
     var userResponseDetails = mock(UserResponseDetails.class);
     var userRequest = mock(UserRequest.class);
     var apiProxy = mock(ApiProxy.class);
-    doReturn(userResponseDetails).when(apiProxy).post(any(), any(), any());
+    var inviteUrl = InviteOptions.builder().inviteUrl("https://mockUrl.com").build();
+		doReturn(userResponseDetails).when(apiProxy).post(any(), any(), any());
+
     try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
       mockedApiProxyBuilder.when(
         () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
-      var response = userService.invite("someLoginId", userRequest);
+      var response = userService.invite("someLoginId", userRequest, inviteUrl);
       Assertions.assertThat(response).isNotNull();
     }
   }

--- a/src/test/java/com/descope/sdk/mgmt/impl/UserServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/UserServiceImplTest.java
@@ -98,7 +98,7 @@ public class UserServiceImplTest {
     var userRequest = mock(UserRequest.class);
     var apiProxy = mock(ApiProxy.class);
     var inviteUrl = InviteOptions.builder().inviteUrl("https://mockUrl.com").build();
-		doReturn(userResponseDetails).when(apiProxy).post(any(), any(), any());
+    doReturn(userResponseDetails).when(apiProxy).post(any(), any(), any());
 
     try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
       mockedApiProxyBuilder.when(


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/4090


## Description
- add invite options (which includes invite URL)
- also changed `replaceUserPassword` to return authentication info (instead https://github.com/descope/descope-java/pull/61)