### PR TITLE
add sendSMS and sendEmail to invite options

### DIFF
--- a/src/main/java/com/descope/model/auth/InviteOptions.java
+++ b/src/main/java/com/descope/model/auth/InviteOptions.java
@@ -11,4 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class InviteOptions {
   private String inviteUrl;
+  private Boolean sendEmail;
+  private Boolean sendSMS;
 }

--- a/src/main/java/com/descope/model/user/request/UserRequest.java
+++ b/src/main/java/com/descope/model/user/request/UserRequest.java
@@ -1,6 +1,7 @@
 package com.descope.model.user.request;
 
 import com.descope.model.auth.AssociatedTenant;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -27,5 +28,8 @@ public class UserRequest {
   Boolean invite;
   Boolean test;
   String inviteUrl;
+  Boolean sendEmail;
+  @JsonProperty("sendSMS")
+  Boolean sendSMS;
   List<String> additionalLoginIds;
 }

--- a/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
@@ -103,7 +103,15 @@ class UserServiceImpl extends ManagementsBase implements UserService {
     request.setTest(false);
 
     if (options != null) {
-      request.setInviteUrl(options.getInviteUrl());
+      if (StringUtils.isNotBlank(options.getInviteUrl())) {
+        request.setInviteUrl(options.getInviteUrl());
+      }
+      if (options.getSendSMS() != null) {
+        request.setSendSMS(options.getSendSMS());        
+      }
+      if (options.getSendEmail() != null) {
+        request.setSendEmail(options.getSendEmail());
+      }
     }
 
     URI createUserUri = composeCreateUserUri();


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/4623

## Description

Add `sendSMS` and `sendEmail` to invite options

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
