### PR TITLE
Add batch create and invite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
             <groupId>uk.org.webcompere</groupId>
             <artifactId>system-stubs-core</artifactId>
             <version>2.0.2</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>uk.org.webcompere</groupId>

--- a/src/main/java/com/descope/enums/BatchUserPasswordAlgorithm.java
+++ b/src/main/java/com/descope/enums/BatchUserPasswordAlgorithm.java
@@ -1,0 +1,19 @@
+package com.descope.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+public enum BatchUserPasswordAlgorithm {
+  BATCH_USER_PASSWORD_ALGORITHM_BCRYPT("bcrypt"),
+  BATCH_USER_PASSWORD_ALGORITHM_PBKDF2SHA1("pbkdf2sha1"),
+  BATCH_USER_PASSWORD_ALGORITHM_PBKDF2SHA256("pbkdf2sha256"),
+  BATCH_USER_PASSWORD_ALGORITHM_PBKDF2SHA512("pbkdf2sha512");
+
+  @Getter
+  @JsonValue
+  private final String value;
+
+  BatchUserPasswordAlgorithm(String value) {
+    this.value = value;
+  }
+}

--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -76,6 +76,7 @@ public class Routes {
   public static class ManagementEndPoints {
     // User
     public static final String CREATE_USER_LINK = "/v1/mgmt/user/create";
+    public static final String CREATE_USERS_BATCH_LINK = "/v1/mgmt/user/create/batch";
     public static final String UPDATE_USER_LINK = "/v1/mgmt/user/update";
     public static final String DELETE_USER_LINK = "/v1/mgmt/user/delete";
     public static final String DELETE_ALL_TEST_USERS_LINK = "/v1/mgmt/user/test/delete/all";

--- a/src/main/java/com/descope/model/user/request/BatchUserPasswordHashed.java
+++ b/src/main/java/com/descope/model/user/request/BatchUserPasswordHashed.java
@@ -1,0 +1,18 @@
+package com.descope.model.user.request;
+
+import com.descope.enums.BatchUserPasswordAlgorithm;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchUserPasswordHashed {
+  BatchUserPasswordAlgorithm algorithm;
+  byte[] hash;
+  byte[] salt;
+  int iterations;
+}

--- a/src/main/java/com/descope/model/user/request/BatchUserRequest.java
+++ b/src/main/java/com/descope/model/user/request/BatchUserRequest.java
@@ -1,0 +1,18 @@
+package com.descope.model.user.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class BatchUserRequest extends UserRequest {
+  String loginId;
+  String password;
+  BatchUserPasswordHashed hashedPassword;
+}

--- a/src/main/java/com/descope/model/user/request/UserRequest.java
+++ b/src/main/java/com/descope/model/user/request/UserRequest.java
@@ -1,35 +1,53 @@
 package com.descope.model.user.request;
 
+
+import static com.descope.utils.CollectionUtils.addIfNotNull;
+
 import com.descope.model.auth.AssociatedTenant;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Data
-@Builder
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserRequest {
-  String userId;
-  String loginId;
   String email;
   Boolean verifiedEmail;
   String phone;
   Boolean verifiedPhone;
   String displayName;
+  String givenName;
+  String middleName;
+  String familyName;
   List<String> roleNames;
   List<AssociatedTenant> userTenants;
   Map<String, Object> customAttributes;
   String picture;
-  Boolean invite;
   Boolean test;
-  String inviteUrl;
-  Boolean sendEmail;
-  @JsonProperty("sendSMS")
-  Boolean sendSMS;
   List<String> additionalLoginIds;
+
+  public Map<String, Object> toMap() {
+    Map<String, Object> m = new HashMap<>();
+    addIfNotNull(m, "email", email);
+    addIfNotNull(m, "verifiedEmail", verifiedEmail);
+    addIfNotNull(m, "phone", phone);
+    addIfNotNull(m, "verifiedPhone", verifiedPhone);
+    addIfNotNull(m, "displayName", displayName);
+    addIfNotNull(m, "givenName", givenName);
+    addIfNotNull(m, "middleName", middleName);
+    addIfNotNull(m, "familyName", familyName);
+    addIfNotNull(m, "roleNames", roleNames);
+    addIfNotNull(m, "userTenants", userTenants);
+    addIfNotNull(m, "customAttributes", customAttributes);
+    addIfNotNull(m, "picture", picture);
+    addIfNotNull(m, "test", test);
+    addIfNotNull(m, "additionalLoginIds", additionalLoginIds);
+    return m;
+  }
 }

--- a/src/main/java/com/descope/model/user/response/UserFailedResponse.java
+++ b/src/main/java/com/descope/model/user/response/UserFailedResponse.java
@@ -1,0 +1,13 @@
+package com.descope.model.user.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserFailedResponse {
+  String failure;
+  UserResponse user;
+}

--- a/src/main/java/com/descope/model/user/response/UsersBatchResponse.java
+++ b/src/main/java/com/descope/model/user/response/UsersBatchResponse.java
@@ -1,0 +1,14 @@
+package com.descope.model.user.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsersBatchResponse {
+  private List<UserResponse> createdUsers;
+  private List<UserFailedResponse> failedUsers;
+}

--- a/src/main/java/com/descope/proxy/impl/AbstractProxyImpl.java
+++ b/src/main/java/com/descope/proxy/impl/AbstractProxyImpl.java
@@ -4,6 +4,7 @@ import com.descope.exception.ErrorCode;
 import com.descope.exception.RateLimitExceededException;
 import com.descope.exception.ServerCommonException;
 import com.descope.model.client.SdkInfo;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayOutputStream;
@@ -136,7 +137,7 @@ abstract class AbstractProxyImpl {
   protected <B, R> R post(URI uri, B body, Class<R> returnClz) {
     final ClassicRequestBuilder builder = ClassicRequestBuilder.post(uri);
     if (body != null) {
-      final ObjectMapper objectMapper = new ObjectMapper();
+      final ObjectMapper objectMapper = new ObjectMapper().setSerializationInclusion(Include.NON_NULL);
       final byte[] payload = objectMapper.writeValueAsBytes(body);
       builder.setEntity(new ByteArrayEntity(payload, ContentType.APPLICATION_JSON));
     }

--- a/src/main/java/com/descope/sdk/mgmt/UserService.java
+++ b/src/main/java/com/descope/sdk/mgmt/UserService.java
@@ -3,6 +3,7 @@ package com.descope.sdk.mgmt;
 import com.descope.enums.DeliveryMethod;
 import com.descope.exception.DescopeException;
 import com.descope.model.auth.InviteOptions;
+import com.descope.model.user.request.BatchUserRequest;
 import com.descope.model.user.request.UserRequest;
 import com.descope.model.user.request.UserSearchRequest;
 import com.descope.model.user.response.AllUsersResponseDetails;
@@ -11,6 +12,7 @@ import com.descope.model.user.response.MagicLinkTestUserResponse;
 import com.descope.model.user.response.OTPTestUserResponse;
 import com.descope.model.user.response.ProviderTokenResponse;
 import com.descope.model.user.response.UserResponseDetails;
+import com.descope.model.user.response.UsersBatchResponse;
 import java.util.List;
 import java.util.Map;
 
@@ -29,6 +31,15 @@ public interface UserService {
    *     thrown.
    */
   UserResponseDetails create(String loginId, UserRequest request) throws DescopeException;
+
+  /**
+   * Create users in batch.
+   *
+   * @param users the {@link List} of users
+   * @return {@link UsersBatchResponse} with successfully created users and failed users
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be thrown.
+   */
+  UsersBatchResponse createBatch(List<BatchUserRequest> users) throws DescopeException;
 
   /**
    * Create a new test user. You can later generate OTP, Magic link and enchanted link to use in the
@@ -62,6 +73,16 @@ public interface UserService {
    *     thrown.
    */
   UserResponseDetails invite(String loginId, UserRequest request, InviteOptions options) throws DescopeException;
+
+  /**
+   * Create users in batch and invite them via an email / text message.
+   *
+   * @param users the {@link List} of users
+   * @param options Additional options for the invitation, such as invite URL.
+   * @return {@link UsersBatchResponse} with successfully created users and failed users
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be thrown.
+   */
+  UsersBatchResponse inviteBatch(List<BatchUserRequest> users, InviteOptions options) throws DescopeException;
 
   /**
    * Update an existing user.

--- a/src/main/java/com/descope/utils/CollectionUtils.java
+++ b/src/main/java/com/descope/utils/CollectionUtils.java
@@ -3,6 +3,7 @@ package com.descope.utils;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * A few utility methods since we are using Java8.
@@ -58,5 +59,17 @@ public class CollectionUtils {
     m.put(k5, v5);
     m.put(k6, v6);
     return m;
+  }
+
+  public static void addIfNotNull(Map<String, Object> m, String k, Object v) {
+    if (v != null) {
+      m.put(k, v);
+    }
+  }
+
+  public static void addIfNotBlank(Map<String, Object> m, String k, String v) {
+    if (StringUtils.isNotBlank(v)) {
+      m.put(k, v);
+    }
   }
 }


### PR DESCRIPTION
2. Clean user objects to correctly reflect reality

## Related Issues

Related to https://github.com/descope/etc/issues/4601

## Description

Add the batch operations for create and invite. Clean the user request objects to not contain duplicate login id and user id.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
