### PR TITLE
Add export and import project APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1188,9 +1188,7 @@ try {
 
 ```
 
-You can manage your project's settings and configurations by exporting your
-project's environment. You can also import previously exported data into
-the same project or a different one.
+You can manage your project's settings and configurations by exporting your project's environment.
 
 ```java
 // Exports the current state of the project
@@ -1200,8 +1198,11 @@ try {
     // Handle the error
 }
 
-const files = await descopeClient.management.project.export();
+```
 
+You can also import previously exported data into the same project or a different one.
+
+```java
 try {
     // Load data from a previous export of this project or some other one
     Map<String, Object> files = ...

--- a/README.md
+++ b/README.md
@@ -1181,7 +1181,33 @@ try {
 // Clone the current project to a new one
 // Note that this action is supported only with a pro license or above.
 try {
-    NewProjectResponse resp = ps.clone("New Project Name", ProjectTag.None);
+    NewProjectResponse resp = ps.cloneProject("New Project Name", ProjectTag.None);
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+```
+
+You can manage your project's settings and configurations by exporting your
+project's environment. You can also import previously exported data into
+the same project or a different one.
+
+```java
+// Exports the current state of the project
+try {
+    ExportProjectResponse resp = ps.exportProject();
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+const files = await descopeClient.management.project.export();
+
+try {
+    // Load data from a previous export of this project or some other one
+    Map<String, Object> files = ...
+
+    // Update the current project's settings to mirror those in the exported data
+    ps.importProject(files);
 } catch (DescopeException de) {
     // Handle the error
 }

--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -156,6 +156,8 @@ public class Routes {
     // Project
     public static final String MANAGEMENT_PROJECT_UPDATE_NAME = "/v1/mgmt/project/update/name";
     public static final String MANAGEMENT_PROJECT_CLONE = "/v1/mgmt/project/clone";
+    public static final String MANAGEMENT_PROJECT_EXPORT = "/v1/mgmt/project/export";
+    public static final String MANAGEMENT_PROJECT_IMPORT = "/v1/mgmt/project/import";
 
     // Audit
     public static final String MANAGEMENT_AUDIT_SEARCH_LINK = "/v1/mgmt/audit/search";

--- a/src/main/java/com/descope/model/project/ExportProjectResponse.java
+++ b/src/main/java/com/descope/model/project/ExportProjectResponse.java
@@ -1,0 +1,15 @@
+package com.descope.model.project;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExportProjectResponse {
+  private Map<String, Object> files;
+}

--- a/src/main/java/com/descope/sdk/mgmt/AuthzService.java
+++ b/src/main/java/com/descope/sdk/mgmt/AuthzService.java
@@ -18,6 +18,7 @@ public interface AuthzService {
    * Schema name can be used for projects to track versioning.
    *
    * @param schema {@link Schema} to save.
+   * @param upgrade Should we upgrade existing schema or ignore any namespace not provided.
    * @throws DescopeException If there occurs any exception, a subtype of this exception will be thrown.
    */
   void saveSchema(Schema schema, boolean upgrade) throws DescopeException;

--- a/src/main/java/com/descope/sdk/mgmt/ProjectService.java
+++ b/src/main/java/com/descope/sdk/mgmt/ProjectService.java
@@ -1,11 +1,10 @@
 package com.descope.sdk.mgmt;
 
-import java.util.Map;
-
 import com.descope.enums.ProjectTag;
 import com.descope.exception.DescopeException;
 import com.descope.model.project.ExportProjectResponse;
 import com.descope.model.project.NewProjectResponse;
+import java.util.Map;
 
 public interface ProjectService {
   /**

--- a/src/main/java/com/descope/sdk/mgmt/ProjectService.java
+++ b/src/main/java/com/descope/sdk/mgmt/ProjectService.java
@@ -34,7 +34,7 @@ public interface ProjectService {
    *  - Users, tenants and access keys are not cloned.
    *  - Secrets, keys and tokens are not stripped from the exported data.
    *
-   * @returns An object containing the exported JSON files payload.
+   * @return An object containing the exported JSON files payload.
    * @throws DescopeException - error upon failure
    */
   ExportProjectResponse exportProject() throws DescopeException;

--- a/src/main/java/com/descope/sdk/mgmt/ProjectService.java
+++ b/src/main/java/com/descope/sdk/mgmt/ProjectService.java
@@ -1,6 +1,7 @@
 package com.descope.sdk.mgmt;
 
 import java.util.Map;
+
 import com.descope.enums.ProjectTag;
 import com.descope.exception.DescopeException;
 import com.descope.model.project.ExportProjectResponse;

--- a/src/main/java/com/descope/sdk/mgmt/ProjectService.java
+++ b/src/main/java/com/descope/sdk/mgmt/ProjectService.java
@@ -1,7 +1,9 @@
 package com.descope.sdk.mgmt;
 
+import java.util.Map;
 import com.descope.enums.ProjectTag;
 import com.descope.exception.DescopeException;
+import com.descope.model.project.ExportProjectResponse;
 import com.descope.model.project.NewProjectResponse;
 
 public interface ProjectService {
@@ -23,5 +25,27 @@ public interface ProjectService {
    * @return {@link NewProjectResponse NewProjectResponse}
    * @throws DescopeException - error upon failure
    */
-  NewProjectResponse clone(String name, ProjectTag tag) throws DescopeException;
+  NewProjectResponse cloneProject(String name, ProjectTag tag) throws DescopeException;
+
+  /**
+   * Exports all settings and configurations for a project and returns the
+   * raw JSON files response as an object.
+   *  - This action is supported only with a pro license or above.
+   *  - Users, tenants and access keys are not cloned.
+   *  - Secrets, keys and tokens are not stripped from the exported data.
+   *
+   * @returns An object containing the exported JSON files payload.
+   * @throws DescopeException - error upon failure
+   */
+  ExportProjectResponse exportProject() throws DescopeException;
+
+  /**
+   * Imports all settings and configurations for a project overriding any
+   * current configuration.
+   *  - This action is supported only with a pro license or above.
+   *  - Secrets, keys and tokens are not overwritten unless overwritten in the input.
+   *
+   * @param files The raw JSON dictionary of files, in the same format as the one returned by calls to export.
+   */
+  void importProject(Map<String, Object> files) throws DescopeException;
 }

--- a/src/main/java/com/descope/sdk/mgmt/UserService.java
+++ b/src/main/java/com/descope/sdk/mgmt/UserService.java
@@ -435,6 +435,7 @@ public interface UserService {
    * however, it will be used instead of any global configuration.
    *
    * @param loginId The loginID is required.
+   * @param uri An ptional redirect URL which will be used instead of any global configuration.
    * @param deliveryMethod Choose the selected delivery method for verification.
    * @return It returns the link for the login (exactly as it sent via Email)
    * @throws DescopeException If there occurs any exception, a subtype of this exception will be
@@ -449,6 +450,7 @@ public interface UserService {
    * provided however, it will be used instead of any global configuration.
    *
    * @param loginId loginId The loginID is required.
+   * @param uri An ptional redirect URL which will be used instead of any global configuration.
    * @return It returns the link for the login (exactly as it sent via Email) and pendingRef which
    *     is used to poll for a valid session
    * @throws DescopeException If there occurs any exception, a subtype of this exception will be

--- a/src/main/java/com/descope/sdk/mgmt/impl/ProjectServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/ProjectServiceImpl.java
@@ -1,10 +1,12 @@
 package com.descope.sdk.mgmt.impl;
 
-import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_UPDATE_NAME;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_CLONE;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_EXPORT;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_IMPORT;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_UPDATE_NAME;
 import static com.descope.utils.CollectionUtils.mapOf;
+
+import java.util.Map;
 
 import com.descope.enums.ProjectTag;
 import com.descope.exception.DescopeException;
@@ -13,7 +15,6 @@ import com.descope.model.project.ExportProjectResponse;
 import com.descope.model.project.NewProjectResponse;
 import com.descope.proxy.ApiProxy;
 import com.descope.sdk.mgmt.ProjectService;
-import java.util.Map;
 
 class ProjectServiceImpl extends ManagementsBase implements ProjectService {
 

--- a/src/main/java/com/descope/sdk/mgmt/impl/ProjectServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/ProjectServiceImpl.java
@@ -1,12 +1,15 @@
 package com.descope.sdk.mgmt.impl;
 
-import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_CLONE;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_UPDATE_NAME;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_CLONE;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_EXPORT;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_IMPORT;
 import static com.descope.utils.CollectionUtils.mapOf;
 
 import com.descope.enums.ProjectTag;
 import com.descope.exception.DescopeException;
 import com.descope.model.client.Client;
+import com.descope.model.project.ExportProjectResponse;
 import com.descope.model.project.NewProjectResponse;
 import com.descope.proxy.ApiProxy;
 import com.descope.sdk.mgmt.ProjectService;
@@ -26,10 +29,24 @@ class ProjectServiceImpl extends ManagementsBase implements ProjectService {
   }
 
   @Override
-  public NewProjectResponse clone(String name, ProjectTag tag) throws DescopeException {
+  public NewProjectResponse cloneProject(String name, ProjectTag tag) throws DescopeException {
     ApiProxy apiProxy = getApiProxy();
     Map<String, Object> request = mapOf("name", name, "tag", tag);
     NewProjectResponse resp = apiProxy.post(getUri(MANAGEMENT_PROJECT_CLONE), request, NewProjectResponse.class);
     return resp;
+  }
+
+  @Override
+  public ExportProjectResponse exportProject() throws DescopeException {
+    ApiProxy apiProxy = getApiProxy();
+    ExportProjectResponse resp = apiProxy.post(getUri(MANAGEMENT_PROJECT_EXPORT), null, ExportProjectResponse.class);
+    return resp;
+  }
+
+  @Override
+  public void importProject(Map<String, Object> files) throws DescopeException {
+    ApiProxy apiProxy = getApiProxy();
+    Map<String, Object> request = mapOf("files", files);
+    apiProxy.post(getUri(MANAGEMENT_PROJECT_IMPORT), request, Void.class);
   }
 }

--- a/src/main/java/com/descope/sdk/mgmt/impl/ProjectServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/ProjectServiceImpl.java
@@ -6,8 +6,6 @@ import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_UPDATE_NAME;
 import static com.descope.utils.CollectionUtils.mapOf;
 
-import java.util.Map;
-
 import com.descope.enums.ProjectTag;
 import com.descope.exception.DescopeException;
 import com.descope.model.client.Client;
@@ -15,6 +13,7 @@ import com.descope.model.project.ExportProjectResponse;
 import com.descope.model.project.NewProjectResponse;
 import com.descope.proxy.ApiProxy;
 import com.descope.sdk.mgmt.ProjectService;
+import java.util.Map;
 
 class ProjectServiceImpl extends ManagementsBase implements ProjectService {
 

--- a/src/test/java/com/descope/sdk/mgmt/impl/ProjectServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/ProjectServiceImplTest.java
@@ -8,19 +8,20 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.descope.enums.ProjectTag;
-import com.descope.model.client.Client;
-import com.descope.model.mgmt.ManagementServices;
-import com.descope.model.project.NewProjectResponse;
-import com.descope.model.project.ExportProjectResponse;
-import com.descope.proxy.ApiProxy;
-import com.descope.proxy.impl.ApiProxyBuilder;
-import com.descope.sdk.TestUtils;
-import com.descope.sdk.mgmt.ProjectService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+
+import com.descope.enums.ProjectTag;
+import com.descope.model.client.Client;
+import com.descope.model.mgmt.ManagementServices;
+import com.descope.model.project.ExportProjectResponse;
+import com.descope.model.project.NewProjectResponse;
+import com.descope.proxy.ApiProxy;
+import com.descope.proxy.impl.ApiProxyBuilder;
+import com.descope.sdk.TestUtils;
+import com.descope.sdk.mgmt.ProjectService;
 
 
 public class ProjectServiceImplTest {

--- a/src/test/java/com/descope/sdk/mgmt/impl/ProjectServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/ProjectServiceImplTest.java
@@ -1,14 +1,18 @@
 package com.descope.sdk.mgmt.impl;
 
+import static com.descope.utils.CollectionUtils.mapOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.descope.enums.ProjectTag;
 import com.descope.model.client.Client;
 import com.descope.model.mgmt.ManagementServices;
 import com.descope.model.project.NewProjectResponse;
+import com.descope.model.project.ExportProjectResponse;
 import com.descope.proxy.ApiProxy;
 import com.descope.proxy.impl.ApiProxyBuilder;
 import com.descope.sdk.TestUtils;
@@ -23,7 +27,8 @@ public class ProjectServiceImplTest {
   private ProjectService projectService;
   private final NewProjectResponse mockCloneResponse = NewProjectResponse.builder()
       .projectId("id1").projectName("name1").build();
-
+  private final ExportProjectResponse mockExportResponse = ExportProjectResponse.builder()
+      .files(mapOf("foo/bar.json", mapOf("a", "b"))).build();
 
   @BeforeEach
   void setUp() {
@@ -50,8 +55,32 @@ public class ProjectServiceImplTest {
     try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
       mockedApiProxyBuilder.when(
           () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
-      NewProjectResponse response = projectService.clone("new-name", ProjectTag.Production);
+      NewProjectResponse response = projectService.cloneProject("new-name", ProjectTag.Production);
       Assertions.assertThat(response.getProjectId()).isNotBlank();
+    }
+  }
+
+  @Test
+  void testExportForSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(mockExportResponse).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(
+          () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      ExportProjectResponse response = projectService.exportProject();
+      Assertions.assertThat(response.getFiles()).isEqualTo(mapOf("foo/bar.json", mapOf("a", "b")));
+    }
+  }
+
+  @Test
+  void testImportForSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(Void.class).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(
+        () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      projectService.importProject(mockExportResponse.getFiles());
+      verify(apiProxy, times(1)).post(any(), any(), any());
     }
   }
 }

--- a/src/test/java/com/descope/sdk/mgmt/impl/ProjectServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/ProjectServiceImplTest.java
@@ -8,11 +8,6 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-
 import com.descope.enums.ProjectTag;
 import com.descope.model.client.Client;
 import com.descope.model.mgmt.ManagementServices;
@@ -22,7 +17,10 @@ import com.descope.proxy.ApiProxy;
 import com.descope.proxy.impl.ApiProxyBuilder;
 import com.descope.sdk.TestUtils;
 import com.descope.sdk.mgmt.ProjectService;
-
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 public class ProjectServiceImplTest {
   private ProjectService projectService;


### PR DESCRIPTION
## Related Issue
Resolves https://github.com/descope/etc/issues/4705

## Description
- Add `exportProject` and `importProject` APIs
- Renamed `clone` to `cloneProject` to match the other APIs (minor breaking change)

## Must
- [X] Tests
- [X] Documentation (if applicable)
