### PR TITLE
Add v1 and v2 to SSO Settings API prefixes

### DIFF
--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -111,11 +111,11 @@ public class Routes {
     public static final String TENANT_SEARCH_ALL_LINK = "/v1/mgmt/tenant/search";
 
     // SSO
-    public static final String SSO_GET_SETTINGS_LINK = "/mgmt/sso/settings";
-    public static final String SSO_DELETE_SETTINGS_LINK = "/mgmt/sso/settings";
-    public static final String SSO_CONFIGURE_SETTINGS_LINK = "/mgmt/sso/settings";
-    public static final String SSO_CONFIGURE_METADATA_LINK = "/mgmt/sso/metadata";
-    public static final String SSO_CONFIGURE_MAPPING_LINK = "/mgmt/sso/mapping";
+    public static final String SSO_GET_SETTINGS_LINK = "/v2/mgmt/sso/settings";
+    public static final String SSO_DELETE_SETTINGS_LINK = "/v1/mgmt/sso/settings";
+    public static final String SSO_CONFIGURE_SETTINGS_LINK = "/v1/mgmt/sso/settings";
+    public static final String SSO_CONFIGURE_METADATA_LINK = "/v1/mgmt/sso/metadata";
+    public static final String SSO_CONFIGURE_MAPPING_LINK = "/v1/mgmt/sso/mapping";
 
     // Group
     public static final String GROUP_LOAD_ALL_LINK = "/v1/mgmt/group/all";


### PR DESCRIPTION
## Related Issues


## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

The SSO settings functions were just returning 404 since the v1 and v2 prefixes weren't included in the API routes.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
