### PR TITLE
Adjust to new set_password APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,16 +767,23 @@ try {
 
 #### Set or Expire User Password
 
-You can set or expire a user's password.
-Note: When setting a password, it will automatically be set as expired unless setActive flag set to True.
+You can set (temporary/active) or expire a user's password.
+Note: When using SetTemporaryPassword password will automatically be set as expired.
 The user will not be able log-in using an expired password, and will be required replace it on next login.
 
 ```java
 UserService us = descopeClient.getManagementServices().getUserService();
 
+// Set a temporary user's password
+try {
+    us.setTemporaryPassword("my-custom-id", "some-password");
+} catch (DescopeException de) {
+    // Handle the error
+}
+
 // Set a user's password
 try {
-    us.setPassword("my-custom-id", "some-password", "set-active-flag");
+    us.setActivePassword("my-custom-id", "some-password");
 } catch (DescopeException de) {
     // Handle the error
 }

--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ try {
 #### Set or Expire User Password
 
 You can set or expire a user's password.
-Note: When setting a password, it will automatically be set as expired.
+Note: When setting a password, it will automatically be set as expired unless setActive flag set to True.
 The user will not be able log-in using an expired password, and will be required replace it on next login.
 
 ```java
@@ -776,7 +776,7 @@ UserService us = descopeClient.getManagementServices().getUserService();
 
 // Set a user's password
 try {
-    us.setPassword("my-custom-id", "some-password");
+    us.setPassword("my-custom-id", "some-password", "set-active-flag");
 } catch (DescopeException de) {
     // Handle the error
 }

--- a/README.md
+++ b/README.md
@@ -767,9 +767,9 @@ try {
 
 #### Set or Expire User Password
 
-You can set (temporary/active) or expire a user's password.
-Note: When using SetTemporaryPassword password will automatically be set as expired.
-The user will not be able log-in using an expired password, and will be required replace it on next login.
+You can set a new active password for a user that they can sign in with.
+You can also set a temporary password that they user will be forced to change on the next login.
+For a user that already has an active password, you can expire their current password, effectively requiring them to change it on the next login.
 
 ```java
 UserService us = descopeClient.getManagementServices().getUserService();

--- a/README.md
+++ b/README.md
@@ -767,9 +767,8 @@ try {
 
 #### Set or Expire User Password
 
-You can set a new active password for a user that they can sign in with.
-You can also set a temporary password that they user will be forced to change on the next login.
-For a user that already has an active password, you can expire their current password, effectively requiring them to change it on the next login.
+You can set a new active password for a user, which they can then use to sign in. You can also set a temporary
+password that the user will be forced to change on the next login.
 
 ```java
 UserService us = descopeClient.getManagementServices().getUserService();

--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -110,7 +110,7 @@ public class Routes {
     public static final String COMPOSE_OTP_FOR_TEST_LINK = "/v1/mgmt/tests/generate/otp";
     public static final String MAGIC_LINK_FOR_TEST_LINK = "/v1/mgmt/tests/generate/magiclink";
     public static final String ENCHANTED_LINK_FOR_TEST_LINK = "/v1/mgmt/tests/generate/enchantedlink";
-	public static final String USER_SET_ACTIVE_PASSWORD_LINK = "/v1/mgmt/user/password/set/active";
+    public static final String USER_SET_ACTIVE_PASSWORD_LINK = "/v1/mgmt/user/password/set/active";
     public static final String USER_SET_PASSWORD_LINK = "/v1/mgmt/user/password/set";
     public static final String USER_SET_TEMPORARY_PASSWORD_LINK = "/v1/mgmt/user/password/set/temporary";
     public static final String USER_EXPIRE_PASSWORD_LINK = "/v1/mgmt/user/password/expire";

--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -111,8 +111,8 @@ public class Routes {
     public static final String MAGIC_LINK_FOR_TEST_LINK = "/v1/mgmt/tests/generate/magiclink";
     public static final String ENCHANTED_LINK_FOR_TEST_LINK = "/v1/mgmt/tests/generate/enchantedlink";
     public static final String USER_SET_PASSWORD_LINK = "/v1/mgmt/user/password/set";
-	public static final String USER_SET_TEMPORARY_PASSWORD_LINK = "/v1/mgmt/user/password/set/temporary";
-	public static final String USER_SET_ACTIVE_PASSWORD_LINK = "/v1/mgmt/user/password/set/active";
+    public static final String USER_SET_TEMPORARY_PASSWORD_LINK = "/v1/mgmt/user/password/set/temporary";
+    public static final String USER_SET_ACTIVE_PASSWORD_LINK = "/v1/mgmt/user/password/set/active";
     public static final String USER_EXPIRE_PASSWORD_LINK = "/v1/mgmt/user/password/expire";
     public static final String USER_CREATE_EMBEDDED_LINK = "/v1/mgmt/user/signin/embeddedlink";
     public static final String USER_HISTORY_LINK = "/v1/mgmt/user/history";

--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -110,9 +110,9 @@ public class Routes {
     public static final String COMPOSE_OTP_FOR_TEST_LINK = "/v1/mgmt/tests/generate/otp";
     public static final String MAGIC_LINK_FOR_TEST_LINK = "/v1/mgmt/tests/generate/magiclink";
     public static final String ENCHANTED_LINK_FOR_TEST_LINK = "/v1/mgmt/tests/generate/enchantedlink";
+	public static final String USER_SET_ACTIVE_PASSWORD_LINK = "/v1/mgmt/user/password/set/active";
     public static final String USER_SET_PASSWORD_LINK = "/v1/mgmt/user/password/set";
     public static final String USER_SET_TEMPORARY_PASSWORD_LINK = "/v1/mgmt/user/password/set/temporary";
-    public static final String USER_SET_ACTIVE_PASSWORD_LINK = "/v1/mgmt/user/password/set/active";
     public static final String USER_EXPIRE_PASSWORD_LINK = "/v1/mgmt/user/password/expire";
     public static final String USER_CREATE_EMBEDDED_LINK = "/v1/mgmt/user/signin/embeddedlink";
     public static final String USER_HISTORY_LINK = "/v1/mgmt/user/history";

--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -111,6 +111,8 @@ public class Routes {
     public static final String MAGIC_LINK_FOR_TEST_LINK = "/v1/mgmt/tests/generate/magiclink";
     public static final String ENCHANTED_LINK_FOR_TEST_LINK = "/v1/mgmt/tests/generate/enchantedlink";
     public static final String USER_SET_PASSWORD_LINK = "/v1/mgmt/user/password/set";
+	public static final String USER_SET_TEMPORARY_PASSWORD_LINK = "/v1/mgmt/user/password/set/temporary";
+	public static final String USER_SET_ACTIVE_PASSWORD_LINK = "/v1/mgmt/user/password/set/active";
     public static final String USER_EXPIRE_PASSWORD_LINK = "/v1/mgmt/user/password/expire";
     public static final String USER_CREATE_EMBEDDED_LINK = "/v1/mgmt/user/signin/embeddedlink";
     public static final String USER_HISTORY_LINK = "/v1/mgmt/user/history";

--- a/src/main/java/com/descope/sdk/mgmt/UserService.java
+++ b/src/main/java/com/descope/sdk/mgmt/UserService.java
@@ -433,7 +433,7 @@ public interface UserService {
    */
   void setActivePassword(String loginId, String password) throws DescopeException;
 
-    /* Deprecated (use setTemporaryPassword() instead *
+  /* Deprecated (use setTemporaryPassword() instead *
    * Set a password for the given login ID. Note: The password will automatically be set as expired.
    * The user will not be able to log-in with this password, and will be required to replace it on
    * next login.

--- a/src/main/java/com/descope/sdk/mgmt/UserService.java
+++ b/src/main/java/com/descope/sdk/mgmt/UserService.java
@@ -424,6 +424,20 @@ public interface UserService {
   void setPassword(String loginId, String password) throws DescopeException;
 
   /**
+   * Set a password for the given login ID. Note: The password will automatically be set as expired
+   * unless setActive flag set to True.
+   * The user will not be able to log-in with this password, and will be required to replace it on
+   * next login.
+   *
+   * @param loginId The loginID is required.
+   * @param password Password.
+   * @param setActive Keep the password active so it will not be expired on next log-in.
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be
+   *     thrown.
+   */
+  void setPassword(String loginId, String password, Boolean setActive) throws DescopeException;
+
+  /**
    * Expire the password for the given login ID. Note: user sign-in with an expired password, the
    * user will get `Password Expired` error. Use the `ResetPassword` or `ReplacePassword` methods to
    * reset/replace the password.

--- a/src/main/java/com/descope/sdk/mgmt/UserService.java
+++ b/src/main/java/com/descope/sdk/mgmt/UserService.java
@@ -412,6 +412,28 @@ public interface UserService {
       throws DescopeException;
 
   /**
+   * Set a temporary password for the given login ID. Note: The password will automatically be set as expired.
+   * The user will not be able to log-in with this password, and will be required to replace it on
+   * next login.
+   *
+   * @param loginId The loginID is required.
+   * @param password Password.
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be
+   *     thrown.
+   */
+  void setTemporaryPassword(String loginId, String password) throws DescopeException;
+
+  /**
+   * Set a password for the given login ID.
+   *
+   * @param loginId The loginID is required.
+   * @param password Password.
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be
+   *     thrown.
+   */
+  void setActivePassword(String loginId, String password) throws DescopeException;
+
+    /* Deprecated (use setTemporaryPassword() instead *
    * Set a password for the given login ID. Note: The password will automatically be set as expired.
    * The user will not be able to log-in with this password, and will be required to replace it on
    * next login.
@@ -422,20 +444,6 @@ public interface UserService {
    *     thrown.
    */
   void setPassword(String loginId, String password) throws DescopeException;
-
-  /**
-   * Set a password for the given login ID. Note: The password will automatically be set as expired
-   * unless setActive flag set to True.
-   * The user will not be able to log-in with this password, and will be required to replace it on
-   * next login.
-   *
-   * @param loginId The loginID is required.
-   * @param password Password.
-   * @param setActive Keep the password active so it will not be expired on next log-in.
-   * @throws DescopeException If there occurs any exception, a subtype of this exception will be
-   *     thrown.
-   */
-  void setPassword(String loginId, String password, Boolean setActive) throws DescopeException;
 
   /**
    * Expire the password for the given login ID. Note: user sign-in with an expired password, the

--- a/src/main/java/com/descope/sdk/mgmt/UserService.java
+++ b/src/main/java/com/descope/sdk/mgmt/UserService.java
@@ -412,7 +412,8 @@ public interface UserService {
       throws DescopeException;
 
   /**
-   * Set a temporary password for the given login ID. Note: The password will automatically be set as expired.
+   * Set a temporary password for the given login ID.
+   * Note: The password will automatically be set as expired.
    * The user will not be able to log-in with this password, and will be required to replace it on
    * next login.
    *
@@ -433,7 +434,8 @@ public interface UserService {
    */
   void setActivePassword(String loginId, String password) throws DescopeException;
 
-  /* Deprecated (use setTemporaryPassword() instead *
+  /**
+   * Deprecated (use setTemporaryPassword() instead.
    * Set a password for the given login ID. Note: The password will automatically be set as expired.
    * The user will not be able to log-in with this password, and will be required to replace it on
    * next login.
@@ -443,6 +445,7 @@ public interface UserService {
    * @throws DescopeException If there occurs any exception, a subtype of this exception will be
    *     thrown.
    */
+  @Deprecated
   void setPassword(String loginId, String password) throws DescopeException;
 
   /**

--- a/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
@@ -25,6 +25,8 @@ import static com.descope.literals.Routes.ManagementEndPoints.USER_REMOVE_ROLES_
 import static com.descope.literals.Routes.ManagementEndPoints.USER_REMOVE_TENANT_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SEARCH_ALL_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_PASSWORD_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_TEMPORARY_PASSWORD_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_ACTIVE_PASSWORD_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_ROLES_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_SSO_APPS_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_UPDATE_EMAIL_LINK;
@@ -476,7 +478,7 @@ class UserServiceImpl extends ManagementsBase implements UserService {
     if (StringUtils.isBlank(password)) {
       throw ServerCommonException.invalidArgument("Password");
     }
-    URI setPasswordUri = composeSetPasswordUri();
+    URI setPasswordUri = composeSetTemporaryPasswordUri();
     Map<String, Object> request = mapOf("loginId", loginId, "password", password, "setActive", false);
     ApiProxy apiProxy = getApiProxy();
     apiProxy.post(setPasswordUri, request, Void.class);
@@ -490,7 +492,7 @@ class UserServiceImpl extends ManagementsBase implements UserService {
     if (StringUtils.isBlank(password)) {
       throw ServerCommonException.invalidArgument("Password");
     }
-    URI setPasswordUri = composeSetPasswordUri();
+    URI setPasswordUri = composeSetActivePasswordUri();
     Map<String, Object> request = mapOf("loginId", loginId, "password", password, "setActive", true);
     ApiProxy apiProxy = getApiProxy();
     apiProxy.post(setPasswordUri, request, Void.class);
@@ -705,6 +707,14 @@ class UserServiceImpl extends ManagementsBase implements UserService {
   }
 
   private URI composeSetPasswordUri() {
+    return getUri(USER_SET_PASSWORD_LINK);
+  }
+
+   private URI composeSetTemporaryPasswordUri() {
+    return getUri(USER_SET_PASSWORD_LINK);
+  }
+
+   private URI composeSetActivePasswordUri() {
     return getUri(USER_SET_PASSWORD_LINK);
   }
 

--- a/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
@@ -24,11 +24,11 @@ import static com.descope.literals.Routes.ManagementEndPoints.USER_HISTORY_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_REMOVE_ROLES_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_REMOVE_TENANT_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SEARCH_ALL_LINK;
-import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_PASSWORD_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_ACTIVE_PASSWORD_LINK;
-import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_TEMPORARY_PASSWORD_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_PASSWORD_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_ROLES_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_SSO_APPS_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_TEMPORARY_PASSWORD_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_UPDATE_EMAIL_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_UPDATE_PHONE_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_UPDATE_STATUS_LINK;
@@ -498,7 +498,7 @@ class UserServiceImpl extends ManagementsBase implements UserService {
     apiProxy.post(setPasswordUri, request, Void.class);
   }
 
-  /* Deprecated */
+  @Deprecated
   @Override
   public void setPassword(String loginId, String password) throws DescopeException {
     if (StringUtils.isBlank(loginId)) {
@@ -711,11 +711,11 @@ class UserServiceImpl extends ManagementsBase implements UserService {
   }
 
   private URI composeSetTemporaryPasswordUri() {
-    return getUri(USER_SET_PASSWORD_LINK);
+    return getUri(USER_SET_TEMPORARY_PASSWORD_LINK);
   }
 
   private URI composeSetActivePasswordUri() {
-    return getUri(USER_SET_PASSWORD_LINK);
+    return getUri(USER_SET_ACTIVE_PASSWORD_LINK);
   }
 
   private URI composeExpirePasswordUri() {

--- a/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
@@ -469,6 +469,35 @@ class UserServiceImpl extends ManagementsBase implements UserService {
   }
 
   @Override
+  public void setTemporaryPassword(String loginId, String password) throws DescopeException {
+    if (StringUtils.isBlank(loginId)) {
+      throw ServerCommonException.invalidArgument("Login ID");
+    }
+    if (StringUtils.isBlank(password)) {
+      throw ServerCommonException.invalidArgument("Password");
+    }
+    URI setPasswordUri = composeSetPasswordUri();
+    Map<String, Object> request = mapOf("loginId", loginId, "password", password, "setActive", false);
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(setPasswordUri, request, Void.class);
+  }
+
+  @Override
+  public void setActivePassword(String loginId, String password) throws DescopeException {
+    if (StringUtils.isBlank(loginId)) {
+      throw ServerCommonException.invalidArgument("Login ID");
+    }
+    if (StringUtils.isBlank(password)) {
+      throw ServerCommonException.invalidArgument("Password");
+    }
+    URI setPasswordUri = composeSetPasswordUri();
+    Map<String, Object> request = mapOf("loginId", loginId, "password", password, "setActive", true);
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(setPasswordUri, request, Void.class);
+  }
+
+ /* Deprecated */
+  @Override
   public void setPassword(String loginId, String password) throws DescopeException {
     if (StringUtils.isBlank(loginId)) {
       throw ServerCommonException.invalidArgument("Login ID");
@@ -478,20 +507,6 @@ class UserServiceImpl extends ManagementsBase implements UserService {
     }
     URI setPasswordUri = composeSetPasswordUri();
     Map<String, Object> request = mapOf("loginId", loginId, "password", password);
-    ApiProxy apiProxy = getApiProxy();
-    apiProxy.post(setPasswordUri, request, Void.class);
-  }
-
-  @Override
-  public void setPassword(String loginId, String password, Boolean setActive) throws DescopeException {
-    if (StringUtils.isBlank(loginId)) {
-      throw ServerCommonException.invalidArgument("Login ID");
-    }
-    if (StringUtils.isBlank(password)) {
-      throw ServerCommonException.invalidArgument("Password");
-    }
-    URI setPasswordUri = composeSetPasswordUri();
-    Map<String, Object> request = mapOf("loginId", loginId, "password", password, "setActive", setActive);
     ApiProxy apiProxy = getApiProxy();
     apiProxy.post(setPasswordUri, request, Void.class);
   }

--- a/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
@@ -25,8 +25,8 @@ import static com.descope.literals.Routes.ManagementEndPoints.USER_REMOVE_ROLES_
 import static com.descope.literals.Routes.ManagementEndPoints.USER_REMOVE_TENANT_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SEARCH_ALL_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_PASSWORD_LINK;
-import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_TEMPORARY_PASSWORD_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_ACTIVE_PASSWORD_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_TEMPORARY_PASSWORD_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_ROLES_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_SSO_APPS_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_UPDATE_EMAIL_LINK;
@@ -498,7 +498,7 @@ class UserServiceImpl extends ManagementsBase implements UserService {
     apiProxy.post(setPasswordUri, request, Void.class);
   }
 
- /* Deprecated */
+  /* Deprecated */
   @Override
   public void setPassword(String loginId, String password) throws DescopeException {
     if (StringUtils.isBlank(loginId)) {
@@ -710,11 +710,11 @@ class UserServiceImpl extends ManagementsBase implements UserService {
     return getUri(USER_SET_PASSWORD_LINK);
   }
 
-   private URI composeSetTemporaryPasswordUri() {
+  private URI composeSetTemporaryPasswordUri() {
     return getUri(USER_SET_PASSWORD_LINK);
   }
 
-   private URI composeSetActivePasswordUri() {
+  private URI composeSetActivePasswordUri() {
     return getUri(USER_SET_PASSWORD_LINK);
   }
 

--- a/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
@@ -483,6 +483,20 @@ class UserServiceImpl extends ManagementsBase implements UserService {
   }
 
   @Override
+  public void setPassword(String loginId, String password, Boolean setActive) throws DescopeException {
+    if (StringUtils.isBlank(loginId)) {
+      throw ServerCommonException.invalidArgument("Login ID");
+    }
+    if (StringUtils.isBlank(password)) {
+      throw ServerCommonException.invalidArgument("Password");
+    }
+    URI setPasswordUri = composeSetPasswordUri();
+    Map<String, Object> request = mapOf("loginId", loginId, "password", password, "setActive", setActive);
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(setPasswordUri, request, Void.class);
+  }
+
+  @Override
   public void expirePassword(String loginId) throws DescopeException {
     if (StringUtils.isBlank(loginId)) {
       throw ServerCommonException.invalidArgument("Login ID");

--- a/src/test/java/com/descope/sdk/mgmt/impl/UserServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/UserServiceImplTest.java
@@ -595,12 +595,23 @@ public class UserServiceImplTest {
   }
 
   @Test
-  void testSetPasswordForSuccess() {
+  void testSetTemporaryPasswordForSuccess() {
     ApiProxy apiProxy = mock(ApiProxy.class);
     doReturn(Void.class).when(apiProxy).post(any(), any(), any());
     try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
       mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
-      userService.setPassword("someLoginId", "somePassword", true);
+      userService.setTemporaryPassword("someLoginId", "somePassword");
+      verify(apiProxy, times(1)).post(any(), any(), any());
+    }
+  }
+
+  @Test
+  void testSetActivePasswordForSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(Void.class).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      userService.setActivePassword("someLoginId", "somePassword");
       verify(apiProxy, times(1)).post(any(), any(), any());
     }
   }

--- a/src/test/java/com/descope/sdk/mgmt/impl/UserServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/UserServiceImplTest.java
@@ -595,6 +595,17 @@ public class UserServiceImplTest {
   }
 
   @Test
+  void testSetPasswordForSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(Void.class).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      userService.setPassword("someLoginId", "somePassword", true);
+      verify(apiProxy, times(1)).post(any(), any(), any());
+    }
+  }
+
+  @Test
   void testExpirePasswordForEmpty() {
     ServerCommonException thrown = assertThrows(ServerCommonException.class, () -> userService.expirePassword(""));
     assertNotNull(thrown);

--- a/src/test/java/com/descope/sdk/mgmt/impl/UserServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/UserServiceImplTest.java
@@ -1075,7 +1075,7 @@ public class UserServiceImplTest {
     assertEquals("Testing Test", user.getName());
     assertEquals("invited", user.getStatus());
     // Set password
-    String password = "1q2w3e4r5t6y!";
+    String password = "WASD+ijklll12!";
     userService.setActivePassword(loginId, password);
     AuthenticationInfo authInfo = passwordService.signIn(loginId, password);
     assertNotNull(authInfo);


### PR DESCRIPTION
Deprecated the user.set_password API by creating two new functions:
user.set_temporary_password(..)
user.set_active_password(..)
The first is the same as the old set_password API and the second set the password and make it active - means it can be used on next login without automatically expired it.