### PR TITLE
Fix/jwt refresh returns new refresh token

### DIFF
--- a/src/main/java/com/descope/sdk/auth/AuthenticationService.java
+++ b/src/main/java/com/descope/sdk/auth/AuthenticationService.java
@@ -2,6 +2,7 @@ package com.descope.sdk.auth;
 
 import com.descope.exception.DescopeException;
 import com.descope.model.auth.AccessKeyLoginOptions;
+import com.descope.model.auth.AuthenticationInfo;
 import com.descope.model.jwt.Token;
 import com.descope.model.user.response.UserHistoryResponse;
 import com.descope.model.user.response.UserResponse;
@@ -20,9 +21,8 @@ public interface AuthenticationService {
   Token validateSessionWithToken(String sessionToken) throws DescopeException;
 
   /**
-   * Use to validate a session of a given request. Should be called before any private API call that
-   * requires authorization. Use the addCookies to apply the cookies to the httpRequest
-   * automatically. Alternatively use ValidateAndRefreshSessionWithTokens with the tokens directly.
+   * Use to refresh the given session using a refresh token. Returns the new session token.
+   * Alternatively use ValidateAndRefreshSessionWithTokens to only refresh the session token if not valid.
    *
    * @param refreshToken - Refresh Token
    * @return {@link Token Token}
@@ -31,8 +31,21 @@ public interface AuthenticationService {
   Token refreshSessionWithToken(String refreshToken) throws DescopeException;
 
   /**
-   * Use to validate a session with the session and refresh tokens. Should be called before any
-   * private API call that requires authorization.
+   * Use to refresh the given session using a refresh token. Returns the new authentication info with tokens.
+   * Should be used when jwt rotation is enabled in the project configuration to retrieve the new refresh token.
+   * Alternatively use ValidateAndRefreshSessionWithTokensAuthenticationInfo
+   * to only refresh the session token if not valid.
+   *
+   * @param refreshToken - Refresh Token
+   * @return {@link AuthenticationInfo the full authentication info including refresh token and user}
+   * @throws DescopeException - error upon failure
+   */
+  AuthenticationInfo refreshSessionWithTokenAuthenticationInfo(String refreshToken) throws DescopeException;
+
+  /**
+   * Use to validate a session with the session and refresh tokens.
+   * If the session token is valid, it is returned in the form of a Token object.
+   * If not, use the refresh token to refresh and return the new session token.
    *
    * @param sessionToken - Session Token
    * @param refreshToken - Refresh Token
@@ -40,6 +53,20 @@ public interface AuthenticationService {
    * @throws DescopeException - error upon failure
    */
   Token validateAndRefreshSessionWithTokens(String sessionToken, String refreshToken)
+      throws DescopeException;
+
+  /**
+   * Use to validate a session with the session and refresh tokens.
+   * Should be used when jwt rotation is enabled in the project configuration to retrieve the new refresh token.
+   * If the session token is valid, it is returned in the form of an AuthenticationInfo object.
+   * If not, use the refresh token to refresh and return the new session token.
+   *
+   * @param sessionToken - Session Token
+   * @param refreshToken - Refresh Token
+   * @return {@link AuthenticationInfo the full authentication info including refresh token and user}
+   * @throws DescopeException - error upon failure
+   */
+  AuthenticationInfo validateAndRefreshSessionWithTokensAuthenticationInfo(String sessionToken, String refreshToken)
       throws DescopeException;
 
   /**

--- a/src/main/java/com/descope/sdk/auth/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/com/descope/sdk/auth/impl/AuthenticationServiceImpl.java
@@ -58,7 +58,11 @@ class AuthenticationServiceImpl extends AuthenticationsBase {
       throw ServerCommonException.missingArguments("refresh token");
     }
 
-    return refreshSession(refreshToken);
+    AuthenticationInfo authInfo = refreshSession(refreshToken);
+    if (authInfo.getRefreshToken() == null) { // refresh token is not returned because jwt rotation is not enabled
+      authInfo.setRefreshToken(validateAndCreateToken(refreshToken));
+    }
+    return authInfo;
   }
 
   @Override

--- a/src/main/java/com/descope/sdk/auth/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/com/descope/sdk/auth/impl/AuthenticationServiceImpl.java
@@ -49,6 +49,15 @@ class AuthenticationServiceImpl extends AuthenticationsBase {
       throw ServerCommonException.missingArguments("refresh token");
     }
 
+    return refreshSession(refreshToken).getToken();
+  }
+
+  @Override
+  public AuthenticationInfo refreshSessionWithTokenAuthenticationInfo(String refreshToken) throws DescopeException {
+    if (StringUtils.isBlank(refreshToken)) {
+      throw ServerCommonException.missingArguments("refresh token");
+    }
+
     return refreshSession(refreshToken);
   }
 
@@ -68,6 +77,26 @@ class AuthenticationServiceImpl extends AuthenticationsBase {
       }
     } else {
       return refreshSessionWithToken(refreshToken);
+    }
+  }
+
+  @Override
+  public AuthenticationInfo validateAndRefreshSessionWithTokensAuthenticationInfo(
+      String sessionToken, String refreshToken) throws DescopeException {
+    if (StringUtils.isAllBlank(sessionToken, refreshToken)) {
+      throw ServerCommonException.missingArguments("Both sessionToken and refreshToken are empty");
+    } else if (StringUtils.isNotBlank(sessionToken)) {
+      try {
+        Token refresh = validateAndCreateToken(refreshToken);
+        return new AuthenticationInfo(validateSessionWithToken(sessionToken), refresh, null, null);
+      } catch (Exception e) {
+        if (StringUtils.isNotBlank(refreshToken)) {
+          return refreshSessionWithTokenAuthenticationInfo(refreshToken);
+        }
+        throw e;
+      }
+    } else {
+      return refreshSessionWithTokenAuthenticationInfo(refreshToken);
     }
   }
 

--- a/src/main/java/com/descope/sdk/auth/impl/AuthenticationsBase.java
+++ b/src/main/java/com/descope/sdk/auth/impl/AuthenticationsBase.java
@@ -116,15 +116,13 @@ abstract class AuthenticationsBase extends SdkServicesBase implements Authentica
     return JwtUtils.getToken(jwt, client);
   }
 
-  Token refreshSession(String refreshToken) {
+  AuthenticationInfo refreshSession(String refreshToken) {
     validateJWT(refreshToken);
     ApiProxy apiProxy = getApiProxy(refreshToken);
     URI refreshTokenLinkURL = composeRefreshTokenLinkURL();
 
     JWTResponse jwtResponse = apiProxy.post(refreshTokenLinkURL, null, JWTResponse.class);
-    AuthenticationInfo authenticationInfo = getAuthenticationInfo(jwtResponse);
-
-    return authenticationInfo.getToken();
+    return getAuthenticationInfo(jwtResponse);
   }
 
   AuthenticationInfo getAuthenticationInfo(JWTResponse jwtResponse) {

--- a/src/test/java/com/descope/sdk/auth/impl/AuthenticationServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/auth/impl/AuthenticationServiceImplTest.java
@@ -124,6 +124,10 @@ public class AuthenticationServiceImplTest {
     assertThat(token.getJwt()).isNotBlank();
     token = authenticationService.refreshSessionWithToken(authInfo.getRefreshToken().getJwt());
     assertThat(token.getJwt()).isNotBlank();
+    authInfo = authenticationService.refreshSessionWithTokenAuthenticationInfo(authInfo.getRefreshToken().getJwt());
+    assertThat(token.getJwt()).isNotBlank();
+    assertThat(authInfo.getRefreshToken()).isNotNull();
+    assertThat(authInfo.getRefreshToken().getJwt()).isNotBlank();
     UserResponse u = authenticationService.me(authInfo.getRefreshToken().getJwt());
     assertThat(u.getEmail()).isEqualTo(loginId);
     authenticationService.logout(authInfo.getRefreshToken().getJwt());


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/10663

## Description

Add methods to support jwt rotation and new refresh token returned from refresh session

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
