### PR TITLE
Generation/Revocation of Tenant Admin SSO Link

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.descope</groupId>
     <artifactId>java-sdk</artifactId>
     <modelVersion>4.0.0</modelVersion>
-    <version>1.0.46</version>
+    <version>1.0.47</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Java library used to integrate with Descope.</description>
     <url>https://github.com/descope/descope-java</url>

--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -120,7 +120,6 @@ public class Routes {
 
     // Tenant
     public static final String CREATE_TENANT_LINK = "/v1/mgmt/tenant/create";
-    public static final String REVOKE_SSO_CONFIGURATION_LINK = "/v1/mgmt/tenant/adminlinks/sso/revoke";
     public static final String UPDATE_TENANT_LINK = "/v1/mgmt/tenant/update";
     public static final String DELETE_TENANT_LINK = "/v1/mgmt/tenant/delete";
     public static final String LOAD_TENANT_LINK = "/v1/mgmt/tenant";
@@ -128,6 +127,7 @@ public class Routes {
     public static final String TENANT_SEARCH_ALL_LINK = "/v1/mgmt/tenant/search";
     public static final String GET_TENANT_SETTINGS_LINK = "/v1/mgmt/tenant/settings";
     public static final String GENERATE_SSO_CONFIGURATION_LINK = "/v2/mgmt/tenant/adminlinks/sso/generate";
+    public static final String REVOKE_SSO_CONFIGURATION_LINK = "/v1/mgmt/tenant/adminlinks/sso/revoke";
 
     // SSO
     public static final String SSO_GET_SETTINGS_LINK = "/v1/mgmt/sso/settings";

--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -126,6 +126,8 @@ public class Routes {
     public static final String LOAD_ALL_TENANTS_LINK = "/v1/mgmt/tenant/all";
     public static final String TENANT_SEARCH_ALL_LINK = "/v1/mgmt/tenant/search";
     public static final String GET_TENANT_SETTINGS_LINK = "/v1/mgmt/tenant/settings";
+    public static final String GENERATE_SSO_CONFIGURATION_LINK = "/v2/mgmt/tenant/adminlinks/sso/generate";
+    public static final String REVOKE_SSO_CONFIGURATION_LINK = "/v2/mgmt/tenant/adminlinks/sso/revoke";
 
     // SSO
     public static final String SSO_GET_SETTINGS_LINK = "/v1/mgmt/sso/settings";

--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -120,6 +120,7 @@ public class Routes {
 
     // Tenant
     public static final String CREATE_TENANT_LINK = "/v1/mgmt/tenant/create";
+    public static final String REVOKE_SSO_CONFIGURATION_LINK = "/v1/mgmt/tenant/adminlinks/sso/revoke";
     public static final String UPDATE_TENANT_LINK = "/v1/mgmt/tenant/update";
     public static final String DELETE_TENANT_LINK = "/v1/mgmt/tenant/delete";
     public static final String LOAD_TENANT_LINK = "/v1/mgmt/tenant";
@@ -127,7 +128,6 @@ public class Routes {
     public static final String TENANT_SEARCH_ALL_LINK = "/v1/mgmt/tenant/search";
     public static final String GET_TENANT_SETTINGS_LINK = "/v1/mgmt/tenant/settings";
     public static final String GENERATE_SSO_CONFIGURATION_LINK = "/v2/mgmt/tenant/adminlinks/sso/generate";
-    public static final String REVOKE_SSO_CONFIGURATION_LINK = "/v2/mgmt/tenant/adminlinks/sso/revoke";
 
     // SSO
     public static final String SSO_GET_SETTINGS_LINK = "/v1/mgmt/sso/settings";

--- a/src/main/java/com/descope/model/tenant/request/GenerateTenantLinkRequest.java
+++ b/src/main/java/com/descope/model/tenant/request/GenerateTenantLinkRequest.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class GenerateTenantLinkRequest {
   String tenantId;
-  /** Expiration duration in seconds */
+  /** Expiration duration in seconds. */
   @JsonProperty("expireTime")
   long expireDuration;
   String ssoId;

--- a/src/main/java/com/descope/model/tenant/request/GenerateTenantLinkRequest.java
+++ b/src/main/java/com/descope/model/tenant/request/GenerateTenantLinkRequest.java
@@ -1,0 +1,24 @@
+package com.descope.model.tenant.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GenerateTenantLinkRequest {
+    @JsonProperty("tenantId")
+    String tenantId;
+    @JsonProperty("expireTime")
+    long expireDuration;
+    @JsonProperty("ssoId")
+    String ssoId;
+    @JsonProperty("email")
+    String email;
+    @JsonProperty("templateId")
+    String templateId;
+}

--- a/src/main/java/com/descope/model/tenant/request/GenerateTenantLinkRequest.java
+++ b/src/main/java/com/descope/model/tenant/request/GenerateTenantLinkRequest.java
@@ -11,14 +11,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GenerateTenantLinkRequest {
-    @JsonProperty("tenantId")
-    String tenantId;
-    @JsonProperty("expireTime")
-    long expireDuration;
-    @JsonProperty("ssoId")
-    String ssoId;
-    @JsonProperty("email")
-    String email;
-    @JsonProperty("templateId")
-    String templateId;
+  @JsonProperty("tenantId")
+  String tenantId;
+  @JsonProperty("expireTime")
+  long expireDuration;
+  @JsonProperty("ssoId")
+  String ssoId;
+  @JsonProperty("email")
+  String email;
+  @JsonProperty("templateId")
+  String templateId;
 }

--- a/src/main/java/com/descope/model/tenant/request/GenerateTenantLinkRequest.java
+++ b/src/main/java/com/descope/model/tenant/request/GenerateTenantLinkRequest.java
@@ -11,14 +11,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GenerateTenantLinkRequest {
-  @JsonProperty("tenantId")
   String tenantId;
+  /** Expiration duration in seconds */
   @JsonProperty("expireTime")
   long expireDuration;
-  @JsonProperty("ssoId")
   String ssoId;
-  @JsonProperty("email")
   String email;
-  @JsonProperty("templateId")
   String templateId;
 }

--- a/src/main/java/com/descope/model/tenant/response/GenerateTenantLinkResponse.java
+++ b/src/main/java/com/descope/model/tenant/response/GenerateTenantLinkResponse.java
@@ -10,5 +10,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GenerateTenantLinkResponse {
-    String adminSSOConfigurationLink;
+  String adminSSOConfigurationLink;
 }

--- a/src/main/java/com/descope/model/tenant/response/GenerateTenantLinkResponse.java
+++ b/src/main/java/com/descope/model/tenant/response/GenerateTenantLinkResponse.java
@@ -1,0 +1,14 @@
+package com.descope.model.tenant.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GenerateTenantLinkResponse {
+    String adminSSOConfigurationLink;
+}

--- a/src/main/java/com/descope/sdk/mgmt/TenantService.java
+++ b/src/main/java/com/descope/sdk/mgmt/TenantService.java
@@ -151,11 +151,7 @@ public interface TenantService {
   /**
    * Generate a link that can be used to configure SSO for the tenant.
    *
-   * @param id Tenant ID
-   * @param expireDuration The duration in seconds after which the link will expire
-   * @param ssoID The SSO ID to use for the link
-   * @param email The email address to associate with the SSO link
-   * @param templateID The template ID to use for the SSO link
+   * @param request The request object containing all necessary parameters
    * @return A link that can be used to configure SSO for the tenant
    * @throws DescopeException in case of errors
    */

--- a/src/main/java/com/descope/sdk/mgmt/TenantService.java
+++ b/src/main/java/com/descope/sdk/mgmt/TenantService.java
@@ -3,6 +3,7 @@ package com.descope.sdk.mgmt;
 import com.descope.exception.DescopeException;
 import com.descope.model.tenant.Tenant;
 import com.descope.model.tenant.TenantSettings;
+import com.descope.model.tenant.request.GenerateTenantLinkRequest;
 import com.descope.model.tenant.request.TenantSearchRequest;
 import java.util.List;
 import java.util.Map;
@@ -158,12 +159,7 @@ public interface TenantService {
    * @return A link that can be used to configure SSO for the tenant
    * @throws DescopeException in case of errors
    */
-  String generateSSOConfigurationLink(
-    String id, 
-    long expireDuration, 
-    String ssoID, 
-    String email, 
-    String templateID) throws DescopeException;
+  String generateSSOConfigurationLink(GenerateTenantLinkRequest request) throws DescopeException;
 
   /**
    * Revoke an existing SSO configuration link for the tenant.

--- a/src/main/java/com/descope/sdk/mgmt/TenantService.java
+++ b/src/main/java/com/descope/sdk/mgmt/TenantService.java
@@ -146,4 +146,26 @@ public interface TenantService {
    * @throws DescopeException in case of errors
    */
   void configureSettings(String id, TenantSettings settings) throws DescopeException;
+
+  /**
+   * Generate a link that can be used to configure SSO for the tenant.
+   * 
+   * @param id Tenant ID
+   * @param expireDuration The duration in seconds after which the link will expire
+   * @param ssoID The SSO ID to use for the link
+   * @param email The email address to associate with the SSO link
+   * @param templateID The template ID to use for the SSO link
+   * @return A link that can be used to configure SSO for the tenant
+   * @throws DescopeException in case of errors
+   */
+  String generateSSOConfigurationLink(String id, long expireDuration, String ssoID, String email, String templateID) throws DescopeException;
+
+  /**
+   * Revoke an existing SSO configuration link for the tenant.
+   * 
+   * @param id Tenant ID
+   * @param ssoID The SSO ID for which the link should be revoked
+   * @throws DescopeException in case of errors
+   */
+  void revokeSSOConfigurationLink(String id, String ssoID) throws DescopeException;
 }

--- a/src/main/java/com/descope/sdk/mgmt/TenantService.java
+++ b/src/main/java/com/descope/sdk/mgmt/TenantService.java
@@ -149,7 +149,7 @@ public interface TenantService {
 
   /**
    * Generate a link that can be used to configure SSO for the tenant.
-   * 
+   *
    * @param id Tenant ID
    * @param expireDuration The duration in seconds after which the link will expire
    * @param ssoID The SSO ID to use for the link
@@ -158,11 +158,16 @@ public interface TenantService {
    * @return A link that can be used to configure SSO for the tenant
    * @throws DescopeException in case of errors
    */
-  String generateSSOConfigurationLink(String id, long expireDuration, String ssoID, String email, String templateID) throws DescopeException;
+  String generateSSOConfigurationLink(
+    String id, 
+    long expireDuration, 
+    String ssoID, 
+    String email, 
+    String templateID) throws DescopeException;
 
   /**
    * Revoke an existing SSO configuration link for the tenant.
-   * 
+   *
    * @param id Tenant ID
    * @param ssoID The SSO ID for which the link should be revoked
    * @throws DescopeException in case of errors

--- a/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
@@ -4,9 +4,9 @@ import static com.descope.literals.Routes.ManagementEndPoints.CREATE_TENANT_LINK
 import static com.descope.literals.Routes.ManagementEndPoints.DELETE_TENANT_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.GENERATE_SSO_CONFIGURATION_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.GET_TENANT_SETTINGS_LINK;
-import static com.descope.literals.Routes.ManagementEndPoints.REVOKE_SSO_CONFIGURATION_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.LOAD_ALL_TENANTS_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.LOAD_TENANT_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.REVOKE_SSO_CONFIGURATION_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.TENANT_SEARCH_ALL_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.UPDATE_TENANT_LINK;
 import static com.descope.utils.CollectionUtils.addIfNotNull;

--- a/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
@@ -195,13 +195,11 @@ class TenantServiceImpl extends ManagementsBase implements TenantService {
       throw ServerCommonException.invalidArgument("tenantId");
     }
 
-    Map<String, Object> req = mapOf(
-        "tenantId", request.getTenantId(),
-        "expireTime", request.getExpireDuration(),
-        "ssoId", request.getSsoId(),
-        "email", request.getEmail(),
-        "templateId", request.getTemplateId()
-    );
+    Map<String, Object> req = mapOf("tenantId", request.getTenantId());
+    addIfNotNull(req, "expireTime", request.getExpireDuration());
+    addIfNotNull(req, "ssoId", request.getSsoId());
+    addIfNotNull(req, "email", request.getEmail());
+    addIfNotNull(req, "templateId", request.getTemplateId());
     
     URI generateSSOConfigurationLinkUri = generateSSOConfigurationLinkUri();
     ApiProxy apiProxy = getApiProxy();

--- a/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
@@ -6,9 +6,9 @@ import static com.descope.literals.Routes.ManagementEndPoints.GET_TENANT_SETTING
 import static com.descope.literals.Routes.ManagementEndPoints.LOAD_ALL_TENANTS_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.LOAD_TENANT_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.TENANT_SEARCH_ALL_LINK;
-import static com.descope.literals.Routes.ManagementEndPoints.UPDATE_TENANT_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.GENERATE_SSO_CONFIGURATION_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.REVOKE_SSO_CONFIGURATION_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.UPDATE_TENANT_LINK;
 import static com.descope.utils.CollectionUtils.addIfNotNull;
 import static com.descope.utils.CollectionUtils.mapOf;
 
@@ -17,7 +17,9 @@ import com.descope.exception.ServerCommonException;
 import com.descope.model.client.Client;
 import com.descope.model.tenant.Tenant;
 import com.descope.model.tenant.TenantSettings;
+import com.descope.model.tenant.request.GenerateTenantLinkRequest;
 import com.descope.model.tenant.request.TenantSearchRequest;
+import com.descope.model.tenant.response.GenerateTenantLinkResponse;
 import com.descope.model.tenant.response.GetAllTenantsResponse;
 import com.descope.proxy.ApiProxy;
 import com.descope.sdk.mgmt.TenantService;
@@ -184,27 +186,27 @@ class TenantServiceImpl extends ManagementsBase implements TenantService {
   }
 
   @Override
-  public String generateSSOConfigurationLink(
-    String tenantId, 
-    long expireDuration, 
-    String ssoID, 
-    String email, 
-    String templateID) throws DescopeException {
-    if (StringUtils.isBlank(tenantId)) {
+  public String generateSSOConfigurationLink(GenerateTenantLinkRequest request) throws DescopeException {
+    if (request == null) {
+      request = GenerateTenantLinkRequest.builder().build();
+    }
+
+    if (StringUtils.isBlank(request.getTenantId())) {
       throw ServerCommonException.invalidArgument("tenantId");
     }
 
     Map<String, Object> req = mapOf(
-        "tenantId", tenantId,
-        "expireTime", expireDuration,
-        "ssoId", ssoID,
-        "email", email,
-        "templateId", templateID
+        "tenantId", request.getTenantId(),
+        "expireTime", request.getExpireDuration(),
+        "ssoId", request.getSsoId(),
+        "email", request.getEmail(),
+        "templateId", request.getTemplateId()
     );
     
     URI generateSSOConfigurationLinkUri = generateSSOConfigurationLinkUri();
     ApiProxy apiProxy = getApiProxy();
-    return apiProxy.post(generateSSOConfigurationLinkUri, req, String.class);
+    GenerateTenantLinkResponse response = apiProxy.post(generateSSOConfigurationLinkUri, req, GenerateTenantLinkResponse.class);
+    return response.getAdminSSOConfigurationLink();
   }
 
   @Override

--- a/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
@@ -5,9 +5,9 @@ import static com.descope.literals.Routes.ManagementEndPoints.DELETE_TENANT_LINK
 import static com.descope.literals.Routes.ManagementEndPoints.GET_TENANT_SETTINGS_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.LOAD_ALL_TENANTS_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.LOAD_TENANT_LINK;
-import static com.descope.literals.Routes.ManagementEndPoints.TENANT_SEARCH_ALL_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.GENERATE_SSO_CONFIGURATION_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.REVOKE_SSO_CONFIGURATION_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.TENANT_SEARCH_ALL_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.UPDATE_TENANT_LINK;
 import static com.descope.utils.CollectionUtils.addIfNotNull;
 import static com.descope.utils.CollectionUtils.mapOf;
@@ -205,7 +205,8 @@ class TenantServiceImpl extends ManagementsBase implements TenantService {
     
     URI generateSSOConfigurationLinkUri = generateSSOConfigurationLinkUri();
     ApiProxy apiProxy = getApiProxy();
-    GenerateTenantLinkResponse response = apiProxy.post(generateSSOConfigurationLinkUri, req, GenerateTenantLinkResponse.class);
+    GenerateTenantLinkResponse response = apiProxy.post(
+      generateSSOConfigurationLinkUri, req, GenerateTenantLinkResponse.class);
     return response.getAdminSSOConfigurationLink();
   }
 

--- a/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
@@ -184,17 +184,22 @@ class TenantServiceImpl extends ManagementsBase implements TenantService {
   }
 
   @Override
-  public String generateSSOConfigurationLink(String id, long expireDuration, String ssoID, String email, String templateID) throws DescopeException {
-    if (StringUtils.isBlank(id)) {
-      throw ServerCommonException.invalidArgument("id");
+  public String generateSSOConfigurationLink(
+    String tenantId, 
+    long expireDuration, 
+    String ssoID, 
+    String email, 
+    String templateID) throws DescopeException {
+    if (StringUtils.isBlank(tenantId)) {
+      throw ServerCommonException.invalidArgument("tenantId");
     }
 
     Map<String, Object> req = mapOf(
-        "id", id,
-        "expireDuration", expireDuration,
-        "ssoID", ssoID,
+        "tenantId", tenantId,
+        "expireTime", expireDuration,
+        "ssoId", ssoID,
         "email", email,
-        "templateID", templateID
+        "templateId", templateID
     );
     
     URI generateSSOConfigurationLinkUri = generateSSOConfigurationLinkUri();
@@ -203,12 +208,12 @@ class TenantServiceImpl extends ManagementsBase implements TenantService {
   }
 
   @Override
-  public void revokeSSOConfigurationLink(String id, String ssoID) throws DescopeException {
-    if (StringUtils.isBlank(id)) {
-      throw ServerCommonException.invalidArgument("id");
+  public void revokeSSOConfigurationLink(String tenantId, String ssoID) throws DescopeException {
+    if (StringUtils.isBlank(tenantId)) {
+      throw ServerCommonException.invalidArgument("tenantId");
     }
 
-    Map<String, Object> req = mapOf("id", id, "ssoID", ssoID);
+    Map<String, Object> req = mapOf("tenantId", tenantId, "ssoId", ssoID);
 
     URI revokeSSOConfigurationLinkUri = revokeSSOConfigurationLinkUri();
     ApiProxy apiProxy = getApiProxy();

--- a/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
@@ -7,6 +7,8 @@ import static com.descope.literals.Routes.ManagementEndPoints.LOAD_ALL_TENANTS_L
 import static com.descope.literals.Routes.ManagementEndPoints.LOAD_TENANT_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.TENANT_SEARCH_ALL_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.UPDATE_TENANT_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.GENERATE_SSO_CONFIGURATION_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.REVOKE_SSO_CONFIGURATION_LINK;
 import static com.descope.utils.CollectionUtils.addIfNotNull;
 import static com.descope.utils.CollectionUtils.mapOf;
 
@@ -181,6 +183,38 @@ class TenantServiceImpl extends ManagementsBase implements TenantService {
     apiProxy.post(configureSettingsUri(), req, Void.class);
   }
 
+  @Override
+  public String generateSSOConfigurationLink(String id, long expireDuration, String ssoID, String email, String templateID) throws DescopeException {
+    if (StringUtils.isBlank(id)) {
+      throw ServerCommonException.invalidArgument("id");
+    }
+
+    Map<String, Object> req = mapOf(
+        "id", id,
+        "expireDuration", expireDuration,
+        "ssoID", ssoID,
+        "email", email,
+        "templateID", templateID
+    );
+    
+    URI generateSSOConfigurationLinkUri = generateSSOConfigurationLinkUri();
+    ApiProxy apiProxy = getApiProxy();
+    return apiProxy.post(generateSSOConfigurationLinkUri, req, String.class);
+  }
+
+  @Override
+  public void revokeSSOConfigurationLink(String id, String ssoID) throws DescopeException {
+    if (StringUtils.isBlank(id)) {
+      throw ServerCommonException.invalidArgument("id");
+    }
+
+    Map<String, Object> req = mapOf("id", id, "ssoID", ssoID);
+
+    URI revokeSSOConfigurationLinkUri = revokeSSOConfigurationLinkUri();
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(revokeSSOConfigurationLinkUri, req, Void.class);
+  }
+
   private URI composeCreateTenantUri() {
     return getUri(CREATE_TENANT_LINK);
   }
@@ -211,5 +245,13 @@ class TenantServiceImpl extends ManagementsBase implements TenantService {
 
   private URI configureSettingsUri() {
     return getUri(GET_TENANT_SETTINGS_LINK);
+  }
+
+  private URI generateSSOConfigurationLinkUri() {
+    return getUri(GENERATE_SSO_CONFIGURATION_LINK);
+  }
+
+  private URI revokeSSOConfigurationLinkUri() {
+    return getUri(REVOKE_SSO_CONFIGURATION_LINK);
   }
 }

--- a/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
@@ -2,11 +2,11 @@ package com.descope.sdk.mgmt.impl;
 
 import static com.descope.literals.Routes.ManagementEndPoints.CREATE_TENANT_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.DELETE_TENANT_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.GENERATE_SSO_CONFIGURATION_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.GET_TENANT_SETTINGS_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.REVOKE_SSO_CONFIGURATION_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.LOAD_ALL_TENANTS_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.LOAD_TENANT_LINK;
-import static com.descope.literals.Routes.ManagementEndPoints.GENERATE_SSO_CONFIGURATION_LINK;
-import static com.descope.literals.Routes.ManagementEndPoints.REVOKE_SSO_CONFIGURATION_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.TENANT_SEARCH_ALL_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.UPDATE_TENANT_LINK;
 import static com.descope.utils.CollectionUtils.addIfNotNull;
@@ -206,7 +206,7 @@ class TenantServiceImpl extends ManagementsBase implements TenantService {
     URI generateSSOConfigurationLinkUri = generateSSOConfigurationLinkUri();
     ApiProxy apiProxy = getApiProxy();
     GenerateTenantLinkResponse response = apiProxy.post(
-      generateSSOConfigurationLinkUri, req, GenerateTenantLinkResponse.class);
+        generateSSOConfigurationLinkUri, req, GenerateTenantLinkResponse.class);
     return response.getAdminSSOConfigurationLink();
   }
 

--- a/src/test/java/com/descope/sdk/mgmt/impl/FGAServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/FGAServiceImplTest.java
@@ -1,19 +1,11 @@
 package com.descope.sdk.mgmt.impl;
 
-import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FGA_CHECK;
-import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FGA_CREATE_RELATIONS;
-import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FGA_DELETE_RELATIONS;
-import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FGA_LOAD_SCHEMA;
-import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FGA_RESOURCES_LOAD;
-import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FGA_RESOURCES_SAVE;
-import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FGA_SAVE_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +22,6 @@ import com.descope.proxy.ApiProxy;
 import com.descope.proxy.impl.ApiProxyBuilder;
 import com.descope.sdk.TestUtils;
 import com.descope.sdk.mgmt.FGAService;
-import com.descope.sdk.mgmt.impl.ManagementServiceBuilder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -94,6 +85,7 @@ class FGAServiceImplTest {
     assertThrows(ServerCommonException.class, () -> fgaService.saveSchema(schema));
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   void testLoadSchema_Success() throws Exception {
     Map<String, Object> response = new HashMap<>();
@@ -145,6 +137,7 @@ class FGAServiceImplTest {
     }
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   void testCheck_Success() throws Exception {
     List<FGARelation> relations = Arrays.asList(
@@ -169,6 +162,7 @@ class FGAServiceImplTest {
     }
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   void testLoadResourcesDetails_Success() throws Exception {
     List<FGAResourceIdentifier> identifiers = Arrays.asList(

--- a/src/test/java/com/descope/sdk/mgmt/impl/TenantServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/TenantServiceImplTest.java
@@ -274,7 +274,7 @@ public class TenantServiceImplTest {
   @Test
   void testGenerateSSOConfigurationLinkForEmptyParams() {
     ServerCommonException thrown = assertThrows(ServerCommonException.class, () 
-      -> tenantService.generateSSOConfigurationLink(GenerateTenantLinkRequest.builder()
+        -> tenantService.generateSSOConfigurationLink(GenerateTenantLinkRequest.builder()
           .tenantId("")
           .expireDuration(0)
           .ssoId("")
@@ -298,7 +298,7 @@ public class TenantServiceImplTest {
       mockedApiProxyBuilder.when(
           () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
       String response = tenantService.generateSSOConfigurationLink(
-        GenerateTenantLinkRequest.builder()
+          GenerateTenantLinkRequest.builder()
             .tenantId("tenant")
             .expireDuration(60 * 60 * 24)
             .ssoId("")
@@ -313,8 +313,8 @@ public class TenantServiceImplTest {
 
   @Test
   void testRevokeSSOConfigurationLinkForEmptyParams() {
-    ServerCommonException thrown = assertThrows(ServerCommonException.class, () 
-      -> tenantService.revokeSSOConfigurationLink("", ""));
+    ServerCommonException thrown = assertThrows(ServerCommonException.class, () ->
+        tenantService.revokeSSOConfigurationLink("", ""));
     assertNotNull(thrown);
     assertEquals("The tenantId argument is invalid", thrown.getMessage());
   }

--- a/src/test/java/com/descope/sdk/mgmt/impl/TenantServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/TenantServiceImplTest.java
@@ -18,7 +18,9 @@ import com.descope.exception.ServerCommonException;
 import com.descope.model.client.Client;
 import com.descope.model.tenant.Tenant;
 import com.descope.model.tenant.TenantSettings;
+import com.descope.model.tenant.request.GenerateTenantLinkRequest;
 import com.descope.model.tenant.request.TenantSearchRequest;
+import com.descope.model.tenant.response.GenerateTenantLinkResponse;
 import com.descope.model.tenant.response.GetAllTenantsResponse;
 import com.descope.proxy.ApiProxy;
 import com.descope.proxy.impl.ApiProxyBuilder;
@@ -272,21 +274,39 @@ public class TenantServiceImplTest {
   @Test
   void testGenerateSSOConfigurationLinkForEmptyParams() {
     ServerCommonException thrown = assertThrows(ServerCommonException.class, () 
-    -> tenantService.generateSSOConfigurationLink("", 0, "", "", ""));
+      -> tenantService.generateSSOConfigurationLink(GenerateTenantLinkRequest.builder()
+          .tenantId("")
+          .expireDuration(0)
+          .ssoId("")
+          .email("")
+          .templateId("")
+          .build()));
     assertNotNull(thrown);
     assertEquals("The tenantId argument is invalid", thrown.getMessage());
   }
 
   @Test
   void testGenerateSSOConfigurationLinkForSuccess() {
+    GenerateTenantLinkResponse mockResponse = GenerateTenantLinkResponse.builder()
+        .adminSSOConfigurationLink("some link")
+        .build();
+
     ApiProxy apiProxy = mock(ApiProxy.class);
-    doReturn(mockTenant).when(apiProxy).get(any(), any());
+
+    doReturn(mockResponse).when(apiProxy).post(any(), any(), any());
     try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
       mockedApiProxyBuilder.when(
           () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
-      tenantService.generateSSOConfigurationLink(
-          "tenant", 60 * 60 * 24, "", "", ""
-      );
+      String response = tenantService.generateSSOConfigurationLink(
+        GenerateTenantLinkRequest.builder()
+            .tenantId("tenant")
+            .expireDuration(60 * 60 * 24)
+            .ssoId("")
+            .email("")
+            .templateId("")
+            .build());
+
+      assertThat(response).isEqualTo("some link");
       verify(apiProxy, times(1)).post(any(), any(), any());
     }
   }
@@ -294,7 +314,7 @@ public class TenantServiceImplTest {
   @Test
   void testRevokeSSOConfigurationLinkForEmptyParams() {
     ServerCommonException thrown = assertThrows(ServerCommonException.class, () 
-    -> tenantService.revokeSSOConfigurationLink("", ""));
+      -> tenantService.revokeSSOConfigurationLink("", ""));
     assertNotNull(thrown);
     assertEquals("The tenantId argument is invalid", thrown.getMessage());
   }
@@ -302,7 +322,7 @@ public class TenantServiceImplTest {
   @Test
   void testRevokeSSOConfigurationLinkForSuccess() {
     ApiProxy apiProxy = mock(ApiProxy.class);
-    doReturn(mockTenant).when(apiProxy).get(any(), any());
+    doReturn(void.class).when(apiProxy).post(any(), any(), any());
     try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
       mockedApiProxyBuilder.when(
           () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);

--- a/src/test/java/com/descope/sdk/mgmt/impl/TenantServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/TenantServiceImplTest.java
@@ -312,6 +312,32 @@ public class TenantServiceImplTest {
   }
 
   @Test
+  void testGenerateSSOConfigurationLinkWithSSOIdForSuccess() {
+    GenerateTenantLinkResponse mockResponse = GenerateTenantLinkResponse.builder()
+        .adminSSOConfigurationLink("some link")
+        .build();
+
+    ApiProxy apiProxy = mock(ApiProxy.class);
+
+    doReturn(mockResponse).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(
+          () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      String response = tenantService.generateSSOConfigurationLink(
+          GenerateTenantLinkRequest.builder()
+            .tenantId("tenant")
+            .expireDuration(60 * 60 * 24)
+            .ssoId("bla")
+            .email("a@a.com")
+            .templateId("template-id")
+            .build());
+
+      assertThat(response).isEqualTo("some link");
+      verify(apiProxy, times(1)).post(any(), any(), any());
+    }
+  }
+
+  @Test
   void testRevokeSSOConfigurationLinkForEmptyParams() {
     ServerCommonException thrown = assertThrows(ServerCommonException.class, () ->
         tenantService.revokeSSOConfigurationLink("", ""));
@@ -327,6 +353,18 @@ public class TenantServiceImplTest {
       mockedApiProxyBuilder.when(
           () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
       tenantService.revokeSSOConfigurationLink("tenant", ""); 
+      verify(apiProxy, times(1)).post(any(), any(), any());
+    }
+  }
+
+  @Test
+  void testRevokeSSOConfigurationLinkWithSSOIdForSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(void.class).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(
+          () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      tenantService.revokeSSOConfigurationLink("tenant", "bla"); 
       verify(apiProxy, times(1)).post(any(), any(), any());
     }
   }

--- a/src/test/java/com/descope/sdk/mgmt/impl/TenantServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/TenantServiceImplTest.java
@@ -261,6 +261,16 @@ public class TenantServiceImplTest {
     tenants = tenantService.searchAll(tenantSearchRequest);
     assertThat(tenants).isEmpty();
 
+    GenerateTenantLinkRequest generateTenantLinkRequest = GenerateTenantLinkRequest.builder()
+        .tenantId(tenantId)
+        .expireDuration(60 * 60 * 24)
+        .build();
+      
+    String link = tenantService.generateSSOConfigurationLink(generateTenantLinkRequest);
+    assertThat(link).isNotBlank();
+
+    tenantService.revokeSSOConfigurationLink(tenantId, "");
+
     tenantSettings.setJitDisabled(true);
     tenantSettings.setAuthType(TenantAuthType.OIDC);
     tenantService.configureSettings(tenantId, tenantSettings);

--- a/src/test/java/com/descope/sdk/mgmt/impl/TenantServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/TenantServiceImplTest.java
@@ -274,7 +274,7 @@ public class TenantServiceImplTest {
     ServerCommonException thrown = assertThrows(ServerCommonException.class, () 
     -> tenantService.generateSSOConfigurationLink("", 0, "", "", ""));
     assertNotNull(thrown);
-    assertEquals("The id argument is invalid", thrown.getMessage());
+    assertEquals("The tenantId argument is invalid", thrown.getMessage());
   }
 
   @Test
@@ -296,7 +296,7 @@ public class TenantServiceImplTest {
     ServerCommonException thrown = assertThrows(ServerCommonException.class, () 
     -> tenantService.revokeSSOConfigurationLink("", ""));
     assertNotNull(thrown);
-    assertEquals("The id argument is invalid", thrown.getMessage());
+    assertEquals("The tenantId argument is invalid", thrown.getMessage());
   }
 
   @Test

--- a/src/test/java/com/descope/sdk/mgmt/impl/TenantServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/TenantServiceImplTest.java
@@ -271,7 +271,8 @@ public class TenantServiceImplTest {
 
   @Test
   void testGenerateSSOConfigurationLinkForEmptyParams() {
-    ServerCommonException thrown = assertThrows(ServerCommonException.class, () -> tenantService.generateSSOConfigurationLink("", 0, "", "", ""));
+    ServerCommonException thrown = assertThrows(ServerCommonException.class, () 
+    -> tenantService.generateSSOConfigurationLink("", 0, "", "", ""));
     assertNotNull(thrown);
     assertEquals("The id argument is invalid", thrown.getMessage());
   }
@@ -284,7 +285,7 @@ public class TenantServiceImplTest {
       mockedApiProxyBuilder.when(
           () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
       tenantService.generateSSOConfigurationLink(
-          "tenant", 60*60*24, "", "", ""
+          "tenant", 60 * 60 * 24, "", "", ""
       );
       verify(apiProxy, times(1)).post(any(), any(), any());
     }
@@ -292,7 +293,8 @@ public class TenantServiceImplTest {
 
   @Test
   void testRevokeSSOConfigurationLinkForEmptyParams() {
-    ServerCommonException thrown = assertThrows(ServerCommonException.class, () -> tenantService.revokeSSOConfigurationLink("", ""));
+    ServerCommonException thrown = assertThrows(ServerCommonException.class, () 
+    -> tenantService.revokeSSOConfigurationLink("", ""));
     assertNotNull(thrown);
     assertEquals("The id argument is invalid", thrown.getMessage());
   }

--- a/src/test/java/com/descope/sdk/mgmt/impl/TenantServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/TenantServiceImplTest.java
@@ -268,4 +268,44 @@ public class TenantServiceImplTest {
     assertThat(tenantSettings.getAuthType()).isEqualTo(TenantAuthType.OIDC);
     tenantService.delete(tenantId);
   }
+
+  @Test
+  void testGenerateSSOConfigurationLinkForEmptyParams() {
+    ServerCommonException thrown = assertThrows(ServerCommonException.class, () -> tenantService.generateSSOConfigurationLink("", 0, "", "", ""));
+    assertNotNull(thrown);
+    assertEquals("The id argument is invalid", thrown.getMessage());
+  }
+
+  @Test
+  void testGenerateSSOConfigurationLinkForSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(mockTenant).when(apiProxy).get(any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(
+          () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      tenantService.generateSSOConfigurationLink(
+          "tenant", 60*60*24, "", "", ""
+      );
+      verify(apiProxy, times(1)).post(any(), any(), any());
+    }
+  }
+
+  @Test
+  void testRevokeSSOConfigurationLinkForEmptyParams() {
+    ServerCommonException thrown = assertThrows(ServerCommonException.class, () -> tenantService.revokeSSOConfigurationLink("", ""));
+    assertNotNull(thrown);
+    assertEquals("The id argument is invalid", thrown.getMessage());
+  }
+
+  @Test
+  void testRevokeSSOConfigurationLinkForSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(mockTenant).when(apiProxy).get(any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(
+          () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      tenantService.revokeSSOConfigurationLink("tenant", ""); 
+      verify(apiProxy, times(1)).post(any(), any(), any());
+    }
+  }
 }


### PR DESCRIPTION
## Related Issues

Fixes [Issue #11475](https://github.com/descope/etc/issues/11475)

## Description

Added generation and revocation of admin/configuration SSO link to the Tenant service with mock testing.

## Must

- [x] Tests
- [ ] Documentation (if applicable)
