### PR TITLE
feat: add CRUD operations and token fetching for outbound applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ build/
 
 # Env variables for dotenv for local testing
 .env
+
+.m2/

--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,4 @@ build/
 # Env variables for dotenv for local testing
 .env
 
-.m2/
+.m2*/

--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -240,6 +240,21 @@ public class Routes {
     public static final String MANAGEMENT_DELETE_OUTBOUND_APP_USER_TOKEN_BY_ID = "/v1/mgmt/outbound/token";
     public static final String MANAGEMENT_DELETE_OUTBOUND_APP_USER_TOKENS = "/v1/mgmt/outbound/tokens";
 
+    // Outbound App CRUD
+    public static final String MANAGEMENT_OUTBOUND_APP_CREATE_LINK = "/v1/mgmt/outbound/app/create";
+    public static final String MANAGEMENT_OUTBOUND_APP_UPDATE_LINK = "/v1/mgmt/outbound/app/update";
+    public static final String MANAGEMENT_OUTBOUND_APP_DELETE_LINK = "/v1/mgmt/outbound/app/delete";
+    public static final String MANAGEMENT_OUTBOUND_APP_LOAD_LINK = "/v1/mgmt/outbound/app";
+    public static final String MANAGEMENT_OUTBOUND_APP_LOAD_ALL_LINK = "/v1/mgmt/outbound/apps";
+  
+    // Outbound App token fetch (latest + tenant)
+    public static final String MANAGEMENT_FETCH_OUTBOUND_APP_USER_TOKEN_LATEST =
+        "/v1/mgmt/outbound/app/user/token/latest";
+    public static final String MANAGEMENT_FETCH_OUTBOUND_APP_TENANT_TOKEN =
+        "/v1/mgmt/outbound/app/tenant/token";
+    public static final String MANAGEMENT_FETCH_OUTBOUND_APP_TENANT_TOKEN_LATEST =
+        "/v1/mgmt/outbound/app/tenant/token/latest";
+
     // Inbound
     public static final String MANAGEMENT_INBOUND_CREATE_APP = "/v1/mgmt/thirdparty/app/create";
     public static final String MANAGEMENT_INBOUND_UPDATE_APP = "/v1/mgmt/thirdparty/app/update";

--- a/src/main/java/com/descope/model/mgmt/ManagementServices.java
+++ b/src/main/java/com/descope/model/mgmt/ManagementServices.java
@@ -8,6 +8,7 @@ import com.descope.sdk.mgmt.FlowService;
 import com.descope.sdk.mgmt.GroupService;
 import com.descope.sdk.mgmt.InboundAppsService;
 import com.descope.sdk.mgmt.JwtService;
+import com.descope.sdk.mgmt.OutboundAppsByTokenService;
 import com.descope.sdk.mgmt.OutboundAppsService;
 import com.descope.sdk.mgmt.PasswordSettingsService;
 import com.descope.sdk.mgmt.PermissionService;
@@ -40,6 +41,7 @@ public class ManagementServices {
   ProjectService projectService;
   PasswordSettingsService passwordSettingsService;
   OutboundAppsService outboundAppsService;
+  OutboundAppsByTokenService outboundAppsByTokenService;
   InboundAppsService inboundAppsService;
   UserCustomAttributesService userCustomAttributesService;
 }

--- a/src/main/java/com/descope/model/outbound/FetchLatestOutboundAppUserTokenRequest.java
+++ b/src/main/java/com/descope/model/outbound/FetchLatestOutboundAppUserTokenRequest.java
@@ -1,0 +1,18 @@
+package com.descope.model.outbound;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FetchLatestOutboundAppUserTokenRequest {
+  private String appId;
+  private String userId;
+  // Optional tenant scope for the token, may be null/empty
+  private String tenantId;
+  private FetchOutboundAppTokenOptions options;
+}

--- a/src/main/java/com/descope/model/outbound/FetchOutboundAppTenantTokenRequest.java
+++ b/src/main/java/com/descope/model/outbound/FetchOutboundAppTenantTokenRequest.java
@@ -1,0 +1,18 @@
+package com.descope.model.outbound;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FetchOutboundAppTenantTokenRequest {
+  private String appId;
+  private String tenantId;
+  private List<String> scopes; // Required for by-scopes endpoint; optional for latest endpoint
+  private FetchOutboundAppTokenOptions options;
+}

--- a/src/main/java/com/descope/model/outbound/FetchOutboundAppTenantTokenResponse.java
+++ b/src/main/java/com/descope/model/outbound/FetchOutboundAppTenantTokenResponse.java
@@ -1,0 +1,14 @@
+package com.descope.model.outbound;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FetchOutboundAppTenantTokenResponse {
+  private OutboundAppToken token;
+}

--- a/src/main/java/com/descope/model/outbound/LoadAllOutboundApplicationsResponse.java
+++ b/src/main/java/com/descope/model/outbound/LoadAllOutboundApplicationsResponse.java
@@ -1,0 +1,14 @@
+package com.descope.model.outbound;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoadAllOutboundApplicationsResponse {
+  private OutboundApp[] apps;
+}

--- a/src/main/java/com/descope/model/outbound/OutboundApp.java
+++ b/src/main/java/com/descope/model/outbound/OutboundApp.java
@@ -1,0 +1,15 @@
+package com.descope.model.outbound;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OutboundApp {
+  private String id;
+  private String name;
+}

--- a/src/main/java/com/descope/model/outbound/OutboundAppCreateResponse.java
+++ b/src/main/java/com/descope/model/outbound/OutboundAppCreateResponse.java
@@ -1,0 +1,14 @@
+package com.descope.model.outbound;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OutboundAppCreateResponse {
+  private String id;
+}

--- a/src/main/java/com/descope/model/outbound/OutboundAppRequest.java
+++ b/src/main/java/com/descope/model/outbound/OutboundAppRequest.java
@@ -1,0 +1,15 @@
+package com.descope.model.outbound;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OutboundAppRequest {
+  private String id;
+  private String name;
+}

--- a/src/main/java/com/descope/sdk/mgmt/OutboundAppsByTokenService.java
+++ b/src/main/java/com/descope/sdk/mgmt/OutboundAppsByTokenService.java
@@ -1,0 +1,22 @@
+package com.descope.sdk.mgmt;
+
+import com.descope.exception.DescopeException;
+import com.descope.model.outbound.FetchLatestOutboundAppUserTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppTenantTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppTenantTokenResponse;
+import com.descope.model.outbound.FetchOutboundAppUserTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppUserTokenResponse;
+
+public interface OutboundAppsByTokenService {
+  FetchOutboundAppUserTokenResponse fetchOutboundAppUserTokenByScopes(
+      String token, FetchOutboundAppUserTokenRequest request) throws DescopeException;
+
+  FetchOutboundAppUserTokenResponse fetchLatestOutboundAppUserToken(
+      String token, FetchLatestOutboundAppUserTokenRequest request) throws DescopeException;
+
+  FetchOutboundAppTenantTokenResponse fetchOutboundAppTenantTokenByScopes(
+      String token, FetchOutboundAppTenantTokenRequest request) throws DescopeException;
+
+  FetchOutboundAppTenantTokenResponse fetchLatestOutboundAppTenantToken(
+      String token, FetchOutboundAppTenantTokenRequest request) throws DescopeException;
+}

--- a/src/main/java/com/descope/sdk/mgmt/OutboundAppsService.java
+++ b/src/main/java/com/descope/sdk/mgmt/OutboundAppsService.java
@@ -2,11 +2,26 @@ package com.descope.sdk.mgmt;
 
 import com.descope.exception.DescopeException;
 import com.descope.model.outbound.DeleteOutboundAppUserTokensRequest;
+import com.descope.model.outbound.FetchLatestOutboundAppUserTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppTenantTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppTenantTokenResponse;
 import com.descope.model.outbound.FetchOutboundAppUserTokenRequest;
 import com.descope.model.outbound.FetchOutboundAppUserTokenResponse;
+import com.descope.model.outbound.OutboundApp;
+import com.descope.model.outbound.OutboundAppCreateResponse;
+import com.descope.model.outbound.OutboundAppRequest;
 
-/** Provides functions for managing outbound application tokens for a user in a project. */
+// Provides functions for managing outbound applications and tokens in a project.
 public interface OutboundAppsService {
+  OutboundAppCreateResponse createApplication(OutboundAppRequest request) throws DescopeException;
+
+  void updateApplication(OutboundAppRequest request) throws DescopeException;
+
+  void deleteApplication(String id) throws DescopeException;
+
+  OutboundApp loadApplication(String id) throws DescopeException;
+
+  OutboundApp[] loadAllApplications() throws DescopeException;
 
   /**
    * Fetch the requested token (if exists) for the given user and outbound application.
@@ -17,6 +32,36 @@ public interface OutboundAppsService {
    */
   FetchOutboundAppUserTokenResponse fetchOutboundAppUserToken(FetchOutboundAppUserTokenRequest request)
       throws DescopeException;
+
+  /**
+   * Fetch the latest token for the given user and outbound application.
+   *
+   * @param request Required appId, userId, optional tenantId and options
+   * @return The latest token
+   * @throws DescopeException in case of errors
+   */
+  FetchOutboundAppUserTokenResponse fetchLatestOutboundAppUserToken(
+      FetchLatestOutboundAppUserTokenRequest request) throws DescopeException;
+
+  /**
+   * Fetch a tenant token by specific scopes for an outbound application.
+   *
+   * @param request Required appId, tenantId, and scopes
+   * @return The requested token
+   * @throws DescopeException in case of errors
+   */
+  FetchOutboundAppTenantTokenResponse fetchOutboundAppTenantTokenByScopes(
+      FetchOutboundAppTenantTokenRequest request) throws DescopeException;
+
+  /**
+   * Fetch the latest tenant token for an outbound application.
+   *
+   * @param request Required appId and tenantId; scopes ignored
+   * @return The latest token
+   * @throws DescopeException in case of errors
+   */
+  FetchOutboundAppTenantTokenResponse fetchLatestOutboundAppTenantToken(
+      FetchOutboundAppTenantTokenRequest request) throws DescopeException;
 
   /**
    * Delete the outbound application token for the given ID.

--- a/src/main/java/com/descope/sdk/mgmt/impl/ManagementServiceBuilder.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/ManagementServiceBuilder.java
@@ -24,6 +24,7 @@ public class ManagementServiceBuilder {
         .passwordSettingsService(new PasswordSettingsServiceImpl(client))
         .ssoApplicationService(new SsoApplicationServiceImpl(client))
         .outboundAppsService(new OutboundAppsServiceImpl(client))
+        .outboundAppsByTokenService(new OutboundAppsByTokenServiceImpl(client))
         .inboundAppsService(new InboundAppsServiceImpl(client))
         .userCustomAttributesService(new UserCustomAttributesServiceImpl(client))
         .build();

--- a/src/main/java/com/descope/sdk/mgmt/impl/ManagementsBase.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/ManagementsBase.java
@@ -1,5 +1,6 @@
 package com.descope.sdk.mgmt.impl;
 
+import com.descope.exception.ServerCommonException;
 import com.descope.model.client.Client;
 import com.descope.proxy.ApiProxy;
 import com.descope.proxy.impl.ApiProxyBuilder;
@@ -30,6 +31,14 @@ abstract class ManagementsBase extends SdkServicesBase implements ManagementServ
     }
 
     String token = String.format("Bearer %s:%s", projectId, refreshToken);
+    return ApiProxyBuilder.buildProxy(() -> token, client);
+  }
+
+  ApiProxy getApiProxyWithBearer(String bearerJwt) {
+    if (StringUtils.isBlank(bearerJwt)) {
+      throw ServerCommonException.invalidArgument("bearerJwt");
+    }
+    String token = String.format("Bearer %s", bearerJwt);
     return ApiProxyBuilder.buildProxy(() -> token, client);
   }
 }

--- a/src/main/java/com/descope/sdk/mgmt/impl/OutboundAppsByTokenServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/OutboundAppsByTokenServiceImpl.java
@@ -1,0 +1,110 @@
+package com.descope.sdk.mgmt.impl;
+
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FETCH_OUTBOUND_APP_TENANT_TOKEN;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FETCH_OUTBOUND_APP_TENANT_TOKEN_LATEST;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FETCH_OUTBOUND_APP_USER_TOKEN;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FETCH_OUTBOUND_APP_USER_TOKEN_LATEST;
+
+import com.descope.exception.DescopeException;
+import com.descope.exception.ServerCommonException;
+import com.descope.model.client.Client;
+import com.descope.model.outbound.FetchLatestOutboundAppUserTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppTenantTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppTenantTokenResponse;
+import com.descope.model.outbound.FetchOutboundAppUserTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppUserTokenResponse;
+import com.descope.proxy.ApiProxy;
+import com.descope.sdk.mgmt.OutboundAppsByTokenService;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+class OutboundAppsByTokenServiceImpl extends ManagementsBase implements OutboundAppsByTokenService {
+
+  OutboundAppsByTokenServiceImpl(Client client) {
+    super(client);
+  }
+
+  @Override
+  public FetchOutboundAppUserTokenResponse fetchOutboundAppUserTokenByScopes(
+      String token, FetchOutboundAppUserTokenRequest request) throws DescopeException {
+    validateToken(token);
+    if (request == null) {
+      throw ServerCommonException.invalidArgument("request");
+    }
+    if (StringUtils.isBlank(request.getAppId())) {
+      throw ServerCommonException.invalidArgument("appId");
+    }
+    if (StringUtils.isBlank(request.getUserId())) {
+      throw ServerCommonException.invalidArgument("userId");
+    }
+    if (CollectionUtils.isEmpty(request.getScopes())) {
+      throw ServerCommonException.invalidArgument("scopes");
+    }
+    ApiProxy apiProxy = getApiProxyWithBearer(token);
+    return apiProxy.post(getUri(MANAGEMENT_FETCH_OUTBOUND_APP_USER_TOKEN), request,
+        FetchOutboundAppUserTokenResponse.class);
+  }
+
+  @Override
+  public FetchOutboundAppUserTokenResponse fetchLatestOutboundAppUserToken(
+      String token, FetchLatestOutboundAppUserTokenRequest request) throws DescopeException {
+    validateToken(token);
+    if (request == null) {
+      throw ServerCommonException.invalidArgument("request");
+    }
+    if (StringUtils.isBlank(request.getAppId())) {
+      throw ServerCommonException.invalidArgument("appId");
+    }
+    if (StringUtils.isBlank(request.getUserId())) {
+      throw ServerCommonException.invalidArgument("userId");
+    }
+    ApiProxy apiProxy = getApiProxyWithBearer(token);
+    return apiProxy.post(getUri(MANAGEMENT_FETCH_OUTBOUND_APP_USER_TOKEN_LATEST), request,
+        FetchOutboundAppUserTokenResponse.class);
+  }
+
+  @Override
+  public FetchOutboundAppTenantTokenResponse fetchOutboundAppTenantTokenByScopes(
+      String token, FetchOutboundAppTenantTokenRequest request) throws DescopeException {
+    validateToken(token);
+    if (request == null) {
+      throw ServerCommonException.invalidArgument("request");
+    }
+    if (StringUtils.isBlank(request.getAppId())) {
+      throw ServerCommonException.invalidArgument("appId");
+    }
+    if (StringUtils.isBlank(request.getTenantId())) {
+      throw ServerCommonException.invalidArgument("tenantId");
+    }
+    if (CollectionUtils.isEmpty(request.getScopes())) {
+      throw ServerCommonException.invalidArgument("scopes");
+    }
+    ApiProxy apiProxy = getApiProxyWithBearer(token);
+    return apiProxy.post(getUri(MANAGEMENT_FETCH_OUTBOUND_APP_TENANT_TOKEN), request,
+        FetchOutboundAppTenantTokenResponse.class);
+  }
+
+  @Override
+  public FetchOutboundAppTenantTokenResponse fetchLatestOutboundAppTenantToken(
+      String token, FetchOutboundAppTenantTokenRequest request) throws DescopeException {
+    validateToken(token);
+    if (request == null) {
+      throw ServerCommonException.invalidArgument("request");
+    }
+    if (StringUtils.isBlank(request.getAppId())) {
+      throw ServerCommonException.invalidArgument("appId");
+    }
+    if (StringUtils.isBlank(request.getTenantId())) {
+      throw ServerCommonException.invalidArgument("tenantId");
+    }
+    ApiProxy apiProxy = getApiProxyWithBearer(token);
+    return apiProxy.post(getUri(MANAGEMENT_FETCH_OUTBOUND_APP_TENANT_TOKEN_LATEST), request,
+        FetchOutboundAppTenantTokenResponse.class);
+  }
+
+  private void validateToken(String token) {
+    if (StringUtils.isBlank(token)) {
+      throw ServerCommonException.invalidArgument("token");
+    }
+  }
+}

--- a/src/main/java/com/descope/sdk/mgmt/impl/OutboundAppsServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/OutboundAppsServiceImpl.java
@@ -2,15 +2,30 @@ package com.descope.sdk.mgmt.impl;
 
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_DELETE_OUTBOUND_APP_USER_TOKENS;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_DELETE_OUTBOUND_APP_USER_TOKEN_BY_ID;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FETCH_OUTBOUND_APP_TENANT_TOKEN;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FETCH_OUTBOUND_APP_TENANT_TOKEN_LATEST;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FETCH_OUTBOUND_APP_USER_TOKEN;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FETCH_OUTBOUND_APP_USER_TOKEN_LATEST;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_OUTBOUND_APP_CREATE_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_OUTBOUND_APP_DELETE_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_OUTBOUND_APP_LOAD_ALL_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_OUTBOUND_APP_LOAD_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_OUTBOUND_APP_UPDATE_LINK;
 import static com.descope.utils.CollectionUtils.mapOf;
 
 import com.descope.exception.DescopeException;
 import com.descope.exception.ServerCommonException;
 import com.descope.model.client.Client;
 import com.descope.model.outbound.DeleteOutboundAppUserTokensRequest;
+import com.descope.model.outbound.FetchLatestOutboundAppUserTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppTenantTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppTenantTokenResponse;
 import com.descope.model.outbound.FetchOutboundAppUserTokenRequest;
 import com.descope.model.outbound.FetchOutboundAppUserTokenResponse;
+import com.descope.model.outbound.LoadAllOutboundApplicationsResponse;
+import com.descope.model.outbound.OutboundApp;
+import com.descope.model.outbound.OutboundAppCreateResponse;
+import com.descope.model.outbound.OutboundAppRequest;
 import com.descope.proxy.ApiProxy;
 import com.descope.sdk.mgmt.OutboundAppsService;
 import org.apache.commons.collections4.CollectionUtils;
@@ -20,6 +35,60 @@ public class OutboundAppsServiceImpl extends ManagementsBase implements Outbound
 
   OutboundAppsServiceImpl(Client client) {
     super(client);
+  }
+
+  // ----- CRUD -----
+  @Override
+  public OutboundAppCreateResponse createApplication(OutboundAppRequest request) throws DescopeException {
+    if (request == null) {
+      throw ServerCommonException.invalidArgument("request");
+    }
+    if (StringUtils.isBlank(request.getName())) {
+      throw ServerCommonException.invalidArgument("request.name");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    return apiProxy.post(getUri(MANAGEMENT_OUTBOUND_APP_CREATE_LINK), request, OutboundAppCreateResponse.class);
+  }
+
+  @Override
+  public void updateApplication(OutboundAppRequest request) throws DescopeException {
+    if (request == null) {
+      throw ServerCommonException.invalidArgument("request");
+    }
+    if (StringUtils.isBlank(request.getId())) {
+      throw ServerCommonException.invalidArgument("request.id");
+    }
+    if (StringUtils.isBlank(request.getName())) {
+      throw ServerCommonException.invalidArgument("request.name");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(MANAGEMENT_OUTBOUND_APP_UPDATE_LINK), request, Void.class);
+  }
+
+  @Override
+  public void deleteApplication(String id) throws DescopeException {
+    if (StringUtils.isBlank(id)) {
+      throw ServerCommonException.invalidArgument("id");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(MANAGEMENT_OUTBOUND_APP_DELETE_LINK), mapOf("id", id), Void.class);
+  }
+
+  @Override
+  public OutboundApp loadApplication(String id) throws DescopeException {
+    if (StringUtils.isBlank(id)) {
+      throw ServerCommonException.invalidArgument("id");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    return apiProxy.get(getQueryParamUri(MANAGEMENT_OUTBOUND_APP_LOAD_LINK, mapOf("id", id)), OutboundApp.class);
+  }
+
+  @Override
+  public OutboundApp[] loadAllApplications() throws DescopeException {
+    ApiProxy apiProxy = getApiProxy();
+    LoadAllOutboundApplicationsResponse res =
+        apiProxy.get(getUri(MANAGEMENT_OUTBOUND_APP_LOAD_ALL_LINK), LoadAllOutboundApplicationsResponse.class);
+    return res.getApps();
   }
 
   @Override
@@ -40,6 +109,23 @@ public class OutboundAppsServiceImpl extends ManagementsBase implements Outbound
     ApiProxy apiProxy = getApiProxy();
     return apiProxy.post(getUri(MANAGEMENT_FETCH_OUTBOUND_APP_USER_TOKEN), request, 
       FetchOutboundAppUserTokenResponse.class);
+  }
+
+  @Override
+  public FetchOutboundAppUserTokenResponse fetchLatestOutboundAppUserToken(
+      FetchLatestOutboundAppUserTokenRequest request) throws DescopeException {
+    if (request == null) {
+      throw ServerCommonException.invalidArgument("request");
+    }
+    if (StringUtils.isBlank(request.getAppId())) {
+      throw ServerCommonException.invalidArgument("appId");
+    }
+    if (StringUtils.isBlank(request.getUserId())) {
+      throw ServerCommonException.invalidArgument("userId");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    return apiProxy.post(getUri(MANAGEMENT_FETCH_OUTBOUND_APP_USER_TOKEN_LATEST), request,
+        FetchOutboundAppUserTokenResponse.class);
   }
 
   @Override
@@ -64,5 +150,42 @@ public class OutboundAppsServiceImpl extends ManagementsBase implements Outbound
     }
     ApiProxy apiProxy = getApiProxy();
     apiProxy.delete(getUri(MANAGEMENT_DELETE_OUTBOUND_APP_USER_TOKENS), request, Void.class);
+  }
+
+  @Override
+  public FetchOutboundAppTenantTokenResponse fetchOutboundAppTenantTokenByScopes(
+      FetchOutboundAppTenantTokenRequest request) throws DescopeException {
+    if (request == null) {
+      throw ServerCommonException.invalidArgument("request");
+    }
+    if (StringUtils.isBlank(request.getAppId())) {
+      throw ServerCommonException.invalidArgument("appId");
+    }
+    if (StringUtils.isBlank(request.getTenantId())) {
+      throw ServerCommonException.invalidArgument("tenantId");
+    }
+    if (CollectionUtils.isEmpty(request.getScopes())) {
+      throw ServerCommonException.invalidArgument("scopes");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    return apiProxy.post(getUri(MANAGEMENT_FETCH_OUTBOUND_APP_TENANT_TOKEN), request,
+        FetchOutboundAppTenantTokenResponse.class);
+  }
+
+  @Override
+  public FetchOutboundAppTenantTokenResponse fetchLatestOutboundAppTenantToken(
+      FetchOutboundAppTenantTokenRequest request) throws DescopeException {
+    if (request == null) {
+      throw ServerCommonException.invalidArgument("request");
+    }
+    if (StringUtils.isBlank(request.getAppId())) {
+      throw ServerCommonException.invalidArgument("appId");
+    }
+    if (StringUtils.isBlank(request.getTenantId())) {
+      throw ServerCommonException.invalidArgument("tenantId");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    return apiProxy.post(getUri(MANAGEMENT_FETCH_OUTBOUND_APP_TENANT_TOKEN_LATEST), request,
+        FetchOutboundAppTenantTokenResponse.class);
   }
 }

--- a/src/test/java/com/descope/sdk/mgmt/impl/OutboundAppsByTokenServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/OutboundAppsByTokenServiceImplTest.java
@@ -1,0 +1,150 @@
+package com.descope.sdk.mgmt.impl;
+
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FETCH_OUTBOUND_APP_TENANT_TOKEN;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FETCH_OUTBOUND_APP_TENANT_TOKEN_LATEST;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FETCH_OUTBOUND_APP_USER_TOKEN;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FETCH_OUTBOUND_APP_USER_TOKEN_LATEST;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.descope.exception.DescopeException;
+import com.descope.exception.ServerCommonException;
+import com.descope.model.client.Client;
+import com.descope.model.outbound.FetchLatestOutboundAppUserTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppTenantTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppTenantTokenResponse;
+import com.descope.model.outbound.FetchOutboundAppUserTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppUserTokenResponse;
+import com.descope.proxy.ApiProxy;
+import com.descope.proxy.impl.ApiProxyBuilder;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class OutboundAppsByTokenServiceImplTest {
+
+  private Client client;
+
+  @BeforeEach
+  void setup() {
+    client = mock(Client.class);
+  when(client.getProjectId()).thenReturn("proj");
+  when(client.getManagementKey()).thenReturn("key");
+  when(client.getUri()).thenReturn("https://api");
+    when(client.getSdkInfo()).thenReturn(null);
+  }
+
+  @Test
+  void validationErrors() {
+    OutboundAppsByTokenServiceImpl svc = new OutboundAppsByTokenServiceImpl(client);
+    assertThrows(ServerCommonException.class, () -> svc.fetchLatestOutboundAppUserToken(null, null));
+    assertThrows(ServerCommonException.class, () -> svc.fetchOutboundAppTenantTokenByScopes(" ", null));
+
+    assertThrows(ServerCommonException.class,
+        () -> svc.fetchOutboundAppUserTokenByScopes("t", new FetchOutboundAppUserTokenRequest()));
+
+    FetchOutboundAppUserTokenRequest u = new FetchOutboundAppUserTokenRequest();
+    u.setAppId("app");
+    assertThrows(ServerCommonException.class, () -> svc.fetchOutboundAppUserTokenByScopes("t", u));
+    u.setUserId("u");
+    assertThrows(ServerCommonException.class, () -> svc.fetchOutboundAppUserTokenByScopes("t", u));
+
+    FetchOutboundAppTenantTokenRequest tr = new FetchOutboundAppTenantTokenRequest();
+    tr.setAppId("app");
+    assertThrows(ServerCommonException.class, () -> svc.fetchOutboundAppTenantTokenByScopes("t", tr));
+    tr.setTenantId("ten");
+    assertThrows(ServerCommonException.class, () -> svc.fetchOutboundAppTenantTokenByScopes("t", tr));
+  }
+
+  @Test
+  void fetchUserTokenByScopes() throws DescopeException {
+    try (MockedStatic<ApiProxyBuilder> builder = org.mockito.Mockito.mockStatic(ApiProxyBuilder.class)) {
+      ApiProxy proxy = mock(ApiProxy.class);
+      builder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(proxy);
+
+      FetchOutboundAppUserTokenResponse resp = new FetchOutboundAppUserTokenResponse();
+  when(proxy.post(any(), any(), eq(FetchOutboundAppUserTokenResponse.class)))
+          .thenReturn(resp);
+
+      OutboundAppsByTokenServiceImpl svc = new OutboundAppsByTokenServiceImpl(client);
+      FetchOutboundAppUserTokenRequest req = new FetchOutboundAppUserTokenRequest();
+      req.setAppId("app");
+      req.setUserId("u");
+      req.setScopes(Arrays.asList("s1"));
+
+      FetchOutboundAppUserTokenResponse out = svc.fetchOutboundAppUserTokenByScopes("token", req);
+      assertNotNull(out);
+      assertEquals(resp, out);
+    }
+  }
+
+  @Test
+  void fetchUserTokenLatest() throws DescopeException {
+    try (MockedStatic<ApiProxyBuilder> builder = org.mockito.Mockito.mockStatic(ApiProxyBuilder.class)) {
+      ApiProxy proxy = mock(ApiProxy.class);
+      builder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(proxy);
+
+      FetchOutboundAppUserTokenResponse resp = new FetchOutboundAppUserTokenResponse();
+  when(proxy.post(any(), any(), eq(FetchOutboundAppUserTokenResponse.class)))
+          .thenReturn(resp);
+
+      OutboundAppsByTokenServiceImpl svc = new OutboundAppsByTokenServiceImpl(client);
+      FetchLatestOutboundAppUserTokenRequest req = new FetchLatestOutboundAppUserTokenRequest();
+      req.setAppId("app");
+      req.setUserId("u");
+
+      FetchOutboundAppUserTokenResponse out = svc.fetchLatestOutboundAppUserToken("token", req);
+      assertNotNull(out);
+      assertEquals(resp, out);
+    }
+  }
+
+  @Test
+  void fetchTenantTokenByScopes() throws DescopeException {
+    try (MockedStatic<ApiProxyBuilder> builder = org.mockito.Mockito.mockStatic(ApiProxyBuilder.class)) {
+      ApiProxy proxy = mock(ApiProxy.class);
+      builder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(proxy);
+
+      FetchOutboundAppTenantTokenResponse resp = new FetchOutboundAppTenantTokenResponse();
+  when(proxy.post(any(), any(), eq(FetchOutboundAppTenantTokenResponse.class)))
+          .thenReturn(resp);
+
+      OutboundAppsByTokenServiceImpl svc = new OutboundAppsByTokenServiceImpl(client);
+      FetchOutboundAppTenantTokenRequest req = new FetchOutboundAppTenantTokenRequest();
+      req.setAppId("app");
+      req.setTenantId("t");
+      req.setScopes(Arrays.asList("s1"));
+
+      FetchOutboundAppTenantTokenResponse out = svc.fetchOutboundAppTenantTokenByScopes("token", req);
+      assertNotNull(out);
+      assertEquals(resp, out);
+    }
+  }
+
+  @Test
+  void fetchTenantTokenLatest() throws DescopeException {
+    try (MockedStatic<ApiProxyBuilder> builder = org.mockito.Mockito.mockStatic(ApiProxyBuilder.class)) {
+      ApiProxy proxy = mock(ApiProxy.class);
+      builder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(proxy);
+
+      FetchOutboundAppTenantTokenResponse resp = new FetchOutboundAppTenantTokenResponse();
+  when(proxy.post(any(), any(), eq(FetchOutboundAppTenantTokenResponse.class)))
+          .thenReturn(resp);
+
+      OutboundAppsByTokenServiceImpl svc = new OutboundAppsByTokenServiceImpl(client);
+      FetchOutboundAppTenantTokenRequest req = new FetchOutboundAppTenantTokenRequest();
+      req.setAppId("app");
+      req.setTenantId("t");
+
+      FetchOutboundAppTenantTokenResponse out = svc.fetchLatestOutboundAppTenantToken("token", req);
+      assertNotNull(out);
+      assertEquals(resp, out);
+    }
+  }
+}

--- a/src/test/java/com/descope/sdk/mgmt/impl/OutboundAppsByTokenServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/OutboundAppsByTokenServiceImplTest.java
@@ -69,7 +69,7 @@ class OutboundAppsByTokenServiceImplTest {
       builder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(proxy);
 
       FetchOutboundAppUserTokenResponse resp = new FetchOutboundAppUserTokenResponse();
-    when(proxy.post(any(), any(), eq(FetchOutboundAppUserTokenResponse.class)))
+      when(proxy.post(any(), any(), eq(FetchOutboundAppUserTokenResponse.class)))
           .thenReturn(resp);
 
       OutboundAppsByTokenServiceImpl svc = new OutboundAppsByTokenServiceImpl(client);
@@ -91,7 +91,7 @@ class OutboundAppsByTokenServiceImplTest {
       builder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(proxy);
 
       FetchOutboundAppUserTokenResponse resp = new FetchOutboundAppUserTokenResponse();
-    when(proxy.post(any(), any(), eq(FetchOutboundAppUserTokenResponse.class)))
+      when(proxy.post(any(), any(), eq(FetchOutboundAppUserTokenResponse.class)))
           .thenReturn(resp);
 
       OutboundAppsByTokenServiceImpl svc = new OutboundAppsByTokenServiceImpl(client);
@@ -112,7 +112,7 @@ class OutboundAppsByTokenServiceImplTest {
       builder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(proxy);
 
       FetchOutboundAppTenantTokenResponse resp = new FetchOutboundAppTenantTokenResponse();
-    when(proxy.post(any(), any(), eq(FetchOutboundAppTenantTokenResponse.class)))
+      when(proxy.post(any(), any(), eq(FetchOutboundAppTenantTokenResponse.class)))
           .thenReturn(resp);
 
       OutboundAppsByTokenServiceImpl svc = new OutboundAppsByTokenServiceImpl(client);
@@ -134,7 +134,7 @@ class OutboundAppsByTokenServiceImplTest {
       builder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(proxy);
 
       FetchOutboundAppTenantTokenResponse resp = new FetchOutboundAppTenantTokenResponse();
-    when(proxy.post(any(), any(), eq(FetchOutboundAppTenantTokenResponse.class)))
+      when(proxy.post(any(), any(), eq(FetchOutboundAppTenantTokenResponse.class)))
           .thenReturn(resp);
 
       OutboundAppsByTokenServiceImpl svc = new OutboundAppsByTokenServiceImpl(client);

--- a/src/test/java/com/descope/sdk/mgmt/impl/OutboundAppsByTokenServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/OutboundAppsByTokenServiceImplTest.java
@@ -34,9 +34,9 @@ class OutboundAppsByTokenServiceImplTest {
   @BeforeEach
   void setup() {
     client = mock(Client.class);
-  when(client.getProjectId()).thenReturn("proj");
-  when(client.getManagementKey()).thenReturn("key");
-  when(client.getUri()).thenReturn("https://api");
+    when(client.getProjectId()).thenReturn("proj");
+    when(client.getManagementKey()).thenReturn("key");
+    when(client.getUri()).thenReturn("https://api");
     when(client.getSdkInfo()).thenReturn(null);
   }
 
@@ -69,7 +69,7 @@ class OutboundAppsByTokenServiceImplTest {
       builder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(proxy);
 
       FetchOutboundAppUserTokenResponse resp = new FetchOutboundAppUserTokenResponse();
-  when(proxy.post(any(), any(), eq(FetchOutboundAppUserTokenResponse.class)))
+    when(proxy.post(any(), any(), eq(FetchOutboundAppUserTokenResponse.class)))
           .thenReturn(resp);
 
       OutboundAppsByTokenServiceImpl svc = new OutboundAppsByTokenServiceImpl(client);
@@ -91,7 +91,7 @@ class OutboundAppsByTokenServiceImplTest {
       builder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(proxy);
 
       FetchOutboundAppUserTokenResponse resp = new FetchOutboundAppUserTokenResponse();
-  when(proxy.post(any(), any(), eq(FetchOutboundAppUserTokenResponse.class)))
+    when(proxy.post(any(), any(), eq(FetchOutboundAppUserTokenResponse.class)))
           .thenReturn(resp);
 
       OutboundAppsByTokenServiceImpl svc = new OutboundAppsByTokenServiceImpl(client);
@@ -112,7 +112,7 @@ class OutboundAppsByTokenServiceImplTest {
       builder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(proxy);
 
       FetchOutboundAppTenantTokenResponse resp = new FetchOutboundAppTenantTokenResponse();
-  when(proxy.post(any(), any(), eq(FetchOutboundAppTenantTokenResponse.class)))
+    when(proxy.post(any(), any(), eq(FetchOutboundAppTenantTokenResponse.class)))
           .thenReturn(resp);
 
       OutboundAppsByTokenServiceImpl svc = new OutboundAppsByTokenServiceImpl(client);
@@ -134,7 +134,7 @@ class OutboundAppsByTokenServiceImplTest {
       builder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(proxy);
 
       FetchOutboundAppTenantTokenResponse resp = new FetchOutboundAppTenantTokenResponse();
-  when(proxy.post(any(), any(), eq(FetchOutboundAppTenantTokenResponse.class)))
+    when(proxy.post(any(), any(), eq(FetchOutboundAppTenantTokenResponse.class)))
           .thenReturn(resp);
 
       OutboundAppsByTokenServiceImpl svc = new OutboundAppsByTokenServiceImpl(client);

--- a/src/test/java/com/descope/sdk/mgmt/impl/OutboundAppsServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/OutboundAppsServiceImplTest.java
@@ -87,7 +87,7 @@ class OutboundAppsServiceImplTest {
     ApiProxy apiProxy = mock(ApiProxy.class);
     doReturn(OutboundAppCreateResponse.builder().id("aid").build()).when(apiProxy).post(any(), any(), any());
     LoadAllOutboundApplicationsResponse listResp =
-      LoadAllOutboundApplicationsResponse.builder().apps(new OutboundApp[] { mockApp }).build();
+        LoadAllOutboundApplicationsResponse.builder().apps(new OutboundApp[] { mockApp }).build();
     doReturn(mockApp, listResp).when(apiProxy).get(any(), any());
     try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
       mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);

--- a/src/test/java/com/descope/sdk/mgmt/impl/OutboundAppsServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/OutboundAppsServiceImplTest.java
@@ -9,19 +9,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
 import com.descope.exception.ServerCommonException;
-import com.descope.model.client.SdkInfo;
 import com.descope.model.client.Client;
+import com.descope.model.client.SdkInfo;
 import com.descope.model.outbound.DeleteOutboundAppUserTokensRequest;
 import com.descope.model.outbound.FetchLatestOutboundAppUserTokenRequest;
 import com.descope.model.outbound.FetchOutboundAppTenantTokenRequest;
 import com.descope.model.outbound.FetchOutboundAppTenantTokenResponse;
 import com.descope.model.outbound.FetchOutboundAppUserTokenRequest;
 import com.descope.model.outbound.FetchOutboundAppUserTokenResponse;
-import com.descope.model.outbound.OutboundAppToken;
+import com.descope.model.outbound.LoadAllOutboundApplicationsResponse;
 import com.descope.model.outbound.OutboundApp;
 import com.descope.model.outbound.OutboundAppCreateResponse;
 import com.descope.model.outbound.OutboundAppRequest;
-import com.descope.model.outbound.LoadAllOutboundApplicationsResponse;
+import com.descope.model.outbound.OutboundAppToken;
 import com.descope.proxy.ApiProxy;
 import com.descope.proxy.impl.ApiProxyBuilder;
 import com.descope.sdk.TestUtils;
@@ -86,9 +86,9 @@ class OutboundAppsServiceImplTest {
   void testCrudSuccess() {
     ApiProxy apiProxy = mock(ApiProxy.class);
     doReturn(OutboundAppCreateResponse.builder().id("aid").build()).when(apiProxy).post(any(), any(), any());
-  LoadAllOutboundApplicationsResponse listResp =
-    LoadAllOutboundApplicationsResponse.builder().apps(new OutboundApp[] { mockApp }).build();
-  doReturn(mockApp, listResp).when(apiProxy).get(any(), any());
+    LoadAllOutboundApplicationsResponse listResp =
+      LoadAllOutboundApplicationsResponse.builder().apps(new OutboundApp[] { mockApp }).build();
+    doReturn(mockApp, listResp).when(apiProxy).get(any(), any());
     try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
       mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
       mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(SdkInfo.class))).thenReturn(apiProxy);

--- a/src/test/java/com/descope/sdk/mgmt/impl/OutboundAppsServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/OutboundAppsServiceImplTest.java
@@ -9,11 +9,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
 import com.descope.exception.ServerCommonException;
+import com.descope.model.client.SdkInfo;
 import com.descope.model.client.Client;
 import com.descope.model.outbound.DeleteOutboundAppUserTokensRequest;
+import com.descope.model.outbound.FetchLatestOutboundAppUserTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppTenantTokenRequest;
+import com.descope.model.outbound.FetchOutboundAppTenantTokenResponse;
 import com.descope.model.outbound.FetchOutboundAppUserTokenRequest;
 import com.descope.model.outbound.FetchOutboundAppUserTokenResponse;
 import com.descope.model.outbound.OutboundAppToken;
+import com.descope.model.outbound.OutboundApp;
+import com.descope.model.outbound.OutboundAppCreateResponse;
+import com.descope.model.outbound.OutboundAppRequest;
+import com.descope.model.outbound.LoadAllOutboundApplicationsResponse;
 import com.descope.proxy.ApiProxy;
 import com.descope.proxy.impl.ApiProxyBuilder;
 import com.descope.sdk.TestUtils;
@@ -39,12 +47,61 @@ class OutboundAppsServiceImplTest {
         .token(mockToken)
         .build();
   private OutboundAppsService outboundAppsService;
+  private final OutboundApp mockApp = OutboundApp.builder().id("aid").name("aname").build();
 
   @BeforeEach
   void setUp() {
     Client client = TestUtils.getClient();
     this.outboundAppsService =
         ManagementServiceBuilder.buildServices(client).getOutboundAppsService();
+  }
+
+  @Test
+  void testCrudValidation() {
+    ServerCommonException thrown = assertThrows(ServerCommonException.class,
+        () -> outboundAppsService.createApplication(null));
+    assertNotNull(thrown);
+    assertEquals("The request argument is invalid", thrown.getMessage());
+    thrown = assertThrows(ServerCommonException.class,
+        () -> outboundAppsService.createApplication(OutboundAppRequest.builder().build()));
+    assertEquals("The request.name argument is invalid", thrown.getMessage());
+
+    thrown = assertThrows(ServerCommonException.class, () -> outboundAppsService.updateApplication(null));
+    assertEquals("The request argument is invalid", thrown.getMessage());
+    thrown = assertThrows(ServerCommonException.class,
+        () -> outboundAppsService.updateApplication(OutboundAppRequest.builder().build()));
+    assertEquals("The request.id argument is invalid", thrown.getMessage());
+    thrown = assertThrows(ServerCommonException.class,
+        () -> outboundAppsService.updateApplication(OutboundAppRequest.builder().id("a").build()));
+    assertEquals("The request.name argument is invalid", thrown.getMessage());
+
+    thrown = assertThrows(ServerCommonException.class, () -> outboundAppsService.deleteApplication(""));
+    assertEquals("The id argument is invalid", thrown.getMessage());
+
+    thrown = assertThrows(ServerCommonException.class, () -> outboundAppsService.loadApplication(""));
+    assertEquals("The id argument is invalid", thrown.getMessage());
+  }
+
+  @Test
+  void testCrudSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(OutboundAppCreateResponse.builder().id("aid").build()).when(apiProxy).post(any(), any(), any());
+  LoadAllOutboundApplicationsResponse listResp =
+    LoadAllOutboundApplicationsResponse.builder().apps(new OutboundApp[] { mockApp }).build();
+  doReturn(mockApp, listResp).when(apiProxy).get(any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(SdkInfo.class))).thenReturn(apiProxy);
+      OutboundAppCreateResponse created = outboundAppsService
+          .createApplication(OutboundAppRequest.builder().name("n1").id("i1").build());
+      assertEquals("aid", created.getId());
+      outboundAppsService.updateApplication(OutboundAppRequest.builder().id("aid").name("n2").build());
+      OutboundApp loaded = outboundAppsService.loadApplication("aid");
+      assertEquals("aid", loaded.getId());
+      OutboundApp[] all = outboundAppsService.loadAllApplications();
+      assertEquals(1, all.length);
+      outboundAppsService.deleteApplication("aid");
+    }
   }
 
   @Test
@@ -79,6 +136,9 @@ class OutboundAppsServiceImplTest {
     try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
       mockedApiProxyBuilder.when(
         () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      // Also stub the single-argument overload used when projectId is blank
+      mockedApiProxyBuilder.when(
+        () -> ApiProxyBuilder.buildProxy(any(SdkInfo.class))).thenReturn(apiProxy);
       FetchOutboundAppUserTokenResponse response = outboundAppsService.fetchOutboundAppUserToken(
           FetchOutboundAppUserTokenRequest.builder()
           .appId("someAppId")
@@ -118,5 +178,128 @@ class OutboundAppsServiceImplTest {
           new DeleteOutboundAppUserTokensRequest("appId", "")));
     assertNotNull(thrown);
     assertEquals("The userId argument is invalid", thrown.getMessage());
+  }
+
+  @Test
+  void testFetchLatestUserTokenValidation() {
+    ServerCommonException thrown =
+        assertThrows(ServerCommonException.class, () -> outboundAppsService.fetchLatestOutboundAppUserToken(null));
+    assertNotNull(thrown);
+    assertEquals("The request argument is invalid", thrown.getMessage());
+
+    thrown = assertThrows(ServerCommonException.class,
+        () -> outboundAppsService.fetchLatestOutboundAppUserToken(
+            FetchLatestOutboundAppUserTokenRequest.builder().build()));
+    assertNotNull(thrown);
+    assertEquals("The appId argument is invalid", thrown.getMessage());
+
+    thrown = assertThrows(ServerCommonException.class,
+        () -> outboundAppsService.fetchLatestOutboundAppUserToken(
+            FetchLatestOutboundAppUserTokenRequest.builder().appId("app").build()));
+    assertNotNull(thrown);
+    assertEquals("The userId argument is invalid", thrown.getMessage());
+  }
+
+  @Test
+  void testFetchLatestUserTokenSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(fetchOutboundAppUserTokenResponse).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(SdkInfo.class))).thenReturn(apiProxy);
+
+      FetchOutboundAppUserTokenResponse response = outboundAppsService.fetchLatestOutboundAppUserToken(
+          FetchLatestOutboundAppUserTokenRequest.builder().appId("someAppId").userId("someUserId").build());
+      assertNotNull(response);
+      assertNotNull(response.getToken());
+      assertEquals("someUserId", response.getToken().getUserId());
+    }
+  }
+
+  @Test
+  void testFetchTenantTokenByScopesValidation() {
+    ServerCommonException thrown = assertThrows(ServerCommonException.class,
+        () -> outboundAppsService.fetchOutboundAppTenantTokenByScopes(null));
+    assertNotNull(thrown);
+    assertEquals("The request argument is invalid", thrown.getMessage());
+
+    thrown = assertThrows(ServerCommonException.class,
+        () -> outboundAppsService.fetchOutboundAppTenantTokenByScopes(
+            FetchOutboundAppTenantTokenRequest.builder().build()));
+    assertNotNull(thrown);
+    assertEquals("The appId argument is invalid", thrown.getMessage());
+
+    thrown = assertThrows(ServerCommonException.class,
+        () -> outboundAppsService.fetchOutboundAppTenantTokenByScopes(
+            FetchOutboundAppTenantTokenRequest.builder().appId("app").build()));
+    assertNotNull(thrown);
+    assertEquals("The tenantId argument is invalid", thrown.getMessage());
+
+    thrown = assertThrows(ServerCommonException.class,
+        () -> outboundAppsService.fetchOutboundAppTenantTokenByScopes(
+            FetchOutboundAppTenantTokenRequest.builder().appId("app").tenantId("t").build()));
+    assertNotNull(thrown);
+    assertEquals("The scopes argument is invalid", thrown.getMessage());
+  }
+
+  @Test
+  void testFetchTenantTokenByScopesSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    FetchOutboundAppTenantTokenResponse tenantResp = FetchOutboundAppTenantTokenResponse.builder()
+        .token(mockToken)
+        .build();
+    doReturn(tenantResp).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(SdkInfo.class))).thenReturn(apiProxy);
+      FetchOutboundAppTenantTokenResponse response = outboundAppsService.fetchOutboundAppTenantTokenByScopes(
+          FetchOutboundAppTenantTokenRequest.builder()
+              .appId("someAppId")
+              .tenantId("someTenant")
+              .scopes(Arrays.asList("scope1"))
+              .build());
+      assertNotNull(response.getToken());
+      assertEquals("someAppId", response.getToken().getAppId());
+    }
+  }
+
+  @Test
+  void testFetchLatestTenantTokenValidation() {
+    ServerCommonException thrown = assertThrows(ServerCommonException.class,
+        () -> outboundAppsService.fetchLatestOutboundAppTenantToken(null));
+    assertNotNull(thrown);
+    assertEquals("The request argument is invalid", thrown.getMessage());
+
+    thrown = assertThrows(ServerCommonException.class,
+        () -> outboundAppsService.fetchLatestOutboundAppTenantToken(
+            FetchOutboundAppTenantTokenRequest.builder().build()));
+    assertNotNull(thrown);
+    assertEquals("The appId argument is invalid", thrown.getMessage());
+
+    thrown = assertThrows(ServerCommonException.class,
+        () -> outboundAppsService.fetchLatestOutboundAppTenantToken(
+            FetchOutboundAppTenantTokenRequest.builder().appId("app").build()));
+    assertNotNull(thrown);
+    assertEquals("The tenantId argument is invalid", thrown.getMessage());
+  }
+
+  @Test
+  void testFetchLatestTenantTokenSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    FetchOutboundAppTenantTokenResponse tenantResp = FetchOutboundAppTenantTokenResponse.builder()
+        .token(mockToken)
+        .build();
+    doReturn(tenantResp).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(SdkInfo.class))).thenReturn(apiProxy);
+      FetchOutboundAppTenantTokenResponse response = outboundAppsService.fetchLatestOutboundAppTenantToken(
+          FetchOutboundAppTenantTokenRequest.builder()
+              .appId("someAppId")
+              .tenantId("someTenant")
+              .build());
+      assertNotNull(response.getToken());
+      assertEquals("someAppId", response.getToken().getAppId());
+    }
   }
 }


### PR DESCRIPTION
## Related Issues

Fixes <link_to_github_issue>

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

Implement CRUD functionality for outbound applications along with token fetching capabilities.
Introduce logic in the new OutboundAppsByTokenService to use the recieved JWT.
Update .gitignore to exclude Maven local repository files.

## Must

- [x] Tests
- [ ] Documentation (if applicable)
