### PR TITLE
feat(auth): add auth management key support for disabled auth methods

### DIFF
--- a/src/main/java/com/descope/client/Config.java
+++ b/src/main/java/com/descope/client/Config.java
@@ -30,6 +30,13 @@ public class Config {
   // fail.
   private String managementKey;
 
+  // AuthManagementKey (optional, "") - used to provide a management key to use
+  // with Authentication APIs whose public access has been disabled.
+  // If empty, this value is retrieved from the DESCOPE_AUTH_MANAGEMENT_KEY
+  // environment variable instead. If neither values are set then any disabled
+  // authentication methods API calls will fail.
+  private String authManagementKey;
+
   // PublicKey (optional, "") - used to override or implicitly use a dedicated public key in order
   // to decrypt and validate the JWT tokens during ValidateSessionRequest().
   // If empty, will attempt to fetch all public keys from the specified project id.
@@ -72,5 +79,12 @@ public class Config {
       this.managementKey = EnvironmentUtils.getManagementKey();
     }
     return this.managementKey;
+  }
+
+  public String initializeAuthManagementKey() {
+    if (StringUtils.isBlank(this.authManagementKey)) {
+      this.authManagementKey = EnvironmentUtils.getAuthManagementKey();
+    }
+    return this.authManagementKey;
   }
 }

--- a/src/main/java/com/descope/client/DescopeClient.java
+++ b/src/main/java/com/descope/client/DescopeClient.java
@@ -49,6 +49,7 @@ public class DescopeClient {
       log.debug("Provided public key is set, forcing only provided public key validation");
     }
     config.initializeManagementKey();
+    config.initializeAuthManagementKey();
     config.initializeBaseURL();
 
     Client client = getClient(config);
@@ -69,6 +70,7 @@ public class DescopeClient {
         .uri(StringUtils.isBlank(config.getDescopeBaseUrl()) ? baseUrl : config.getDescopeBaseUrl())
         .projectId(projectId)
         .managementKey(config.getManagementKey())
+        .authManagementKey(config.getAuthManagementKey())
         .headers(
             Collections.isEmpty(config.getCustomDefaultHeaders())
               ? new HashMap<>() : new HashMap<>(config.getCustomDefaultHeaders()))

--- a/src/main/java/com/descope/literals/AppConstants.java
+++ b/src/main/java/com/descope/literals/AppConstants.java
@@ -7,6 +7,7 @@ public class AppConstants {
   public static final String PROJECT_ID_ENV_VAR = "DESCOPE_PROJECT_ID";
   public static final String PUBLIC_KEY_ENV_VAR = "DESCOPE_PUBLIC_KEY";
   public static final String MANAGEMENT_KEY_ENV_VAR = "DESCOPE_MANAGEMENT_KEY";
+  public static final String AUTH_MANAGEMENT_KEY_ENV_VAR = "DESCOPE_AUTH_MANAGEMENT_KEY";
   public static final String BASE_URL_ENV_VAR = "DESCOPE_BASE_URL";
   public static final String AUTHORIZATION_HEADER_NAME = "Authorization";
   public static final String BEARER_AUTHORIZATION_PREFIX = "Bearer ";

--- a/src/main/java/com/descope/model/client/Client.java
+++ b/src/main/java/com/descope/model/client/Client.java
@@ -18,6 +18,7 @@ public class Client {
   private String uri;
   private String projectId;
   private String managementKey;
+  private String authManagementKey;
   private Map<String, String> headers;
   private SdkInfo sdkInfo;
   private Key providedKey;

--- a/src/main/java/com/descope/sdk/auth/impl/AuthenticationsBase.java
+++ b/src/main/java/com/descope/sdk/auth/impl/AuthenticationsBase.java
@@ -37,7 +37,11 @@ abstract class AuthenticationsBase extends SdkServicesBase implements Authentica
 
   ApiProxy getApiProxy() {
     String projectId = client.getProjectId();
+    String authManagementKey = client.getAuthManagementKey();
     if (StringUtils.isNotBlank(projectId)) {
+      if (StringUtils.isNotBlank(authManagementKey)) {
+        return ApiProxyBuilder.buildProxy(() -> String.format("Bearer %s:%s", projectId, authManagementKey), client);
+      }
       return ApiProxyBuilder.buildProxy(() -> "Bearer " + projectId, client);
     }
     return ApiProxyBuilder.buildProxy(client.getSdkInfo());
@@ -49,7 +53,13 @@ abstract class AuthenticationsBase extends SdkServicesBase implements Authentica
       return getApiProxy();
     }
 
-    String token = String.format("Bearer %s:%s", projectId, refreshToken);
+    String authManagementKey = client.getAuthManagementKey();
+    String token;
+    if (StringUtils.isNotBlank(authManagementKey)) {
+      token = String.format("Bearer %s:%s:%s", projectId, refreshToken, authManagementKey);
+    } else {
+      token = String.format("Bearer %s:%s", projectId, refreshToken);
+    }
     return ApiProxyBuilder.buildProxy(() -> token, client);
   }
 

--- a/src/main/java/com/descope/utils/EnvironmentUtils.java
+++ b/src/main/java/com/descope/utils/EnvironmentUtils.java
@@ -1,5 +1,6 @@
 package com.descope.utils;
 
+import static com.descope.literals.AppConstants.AUTH_MANAGEMENT_KEY_ENV_VAR;
 import static com.descope.literals.AppConstants.BASE_URL_ENV_VAR;
 import static com.descope.literals.AppConstants.MANAGEMENT_KEY_ENV_VAR;
 import static com.descope.literals.AppConstants.PROJECT_ID_ENV_VAR;
@@ -26,5 +27,9 @@ public class EnvironmentUtils {
 
   public static String getManagementKey() {
     return dotenv.get(MANAGEMENT_KEY_ENV_VAR);
+  }
+
+  public static String getAuthManagementKey() {
+    return dotenv.get(AUTH_MANAGEMENT_KEY_ENV_VAR);
   }
 }


### PR DESCRIPTION
Fixes descope/etc#8683

[View workflow run](https://github.com/descope/shuni/actions/runs/21035935483)

Perfect! All files are saved and up to date. The implementation is complete!

## Summary

I've successfully implemented the **Auth Management Key** feature in the descope-java SDK, following the same pattern used in the Go SDK reference implementation. Here's what was accomplished:

### Changes Made

1. **Added Environment Variable Support** (src/main/java/com/descope/literals/AppConstants.java:10)
   - Added `AUTH_MANAGEMENT_KEY_ENV_VAR = "DESCOPE_AUTH_MANAGEMENT_KEY"` constant

2. **Added Environment Variable Getter** (src/main/java/com/descope/utils/EnvironmentUtils.java:32-34)
   - Implemented `getAuthManagementKey()` method to retrieve from environment

3. **Extended Configuration** (src/main/java/com/descope/client/Config.java:33-38, 84-89)
   - Added `authManagementKey` field with documentation
   - Added `initializeAuthManagementKey()` initialization method

4. **Updated Client Model** (src/main/java/com/descope/model/client/Client.java:21)
   - Added `authManagementKey` field to store the key

5. **Modified Client Initialization** (src/main/java/com/descope/client/DescopeClient.java:52, 73)
   - Initialize auth management key during client setup
   - Pass auth management key to Client builder

6. **Enhanced Auth API Calls** (src/main/java/com/descope/sdk/auth/impl/AuthenticationsBase.java:40-47, 56-62)
   - Updated `getApiProxy()` to include auth management key in Authorization header
   - Updated `getApiProxy(String refreshToken)` to include auth management key with refresh token
   - Format: `Bearer <projectID>:<authManagementKey>` or `Bearer <projectID>:<refreshToken>:<authManagementKey>`

### Usage

The auth management key can be configured via:

**Environment variable:**
```bash
export DESCOPE_AUTH_MANAGEMENT_KEY="your-auth-management-key"
```

**Code configuration:**
```java
var descopeClient = new DescopeClient(
    Config.builder()
        .projectId("your-project-id")
        .authManagementKey("your-auth-management-key")
        .build()
);
```

### Key Points

- The implementation follows the existing Java SDK patterns and Go SDK reference
- Auth management key is optional and separate from the regular management key
- When provided, it's automatically included in all authentication API calls
- The code compiles successfully without errors
- All files have been saved to the working directory

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*