### PR TITLE
feat: add IDPResponse to AuthenticationInfo for SSO exchange

### DIFF
--- a/src/main/java/com/descope/model/auth/AuthenticationInfo.java
+++ b/src/main/java/com/descope/model/auth/AuthenticationInfo.java
@@ -12,4 +12,5 @@ public class AuthenticationInfo {
   private Token refreshToken;
   private UserResponse user;
   private Boolean firstSeen;
+  private IDPResponse idpResponse;
 }

--- a/src/main/java/com/descope/model/auth/AuthenticationInfo.java
+++ b/src/main/java/com/descope/model/auth/AuthenticationInfo.java
@@ -13,4 +13,8 @@ public class AuthenticationInfo {
   private UserResponse user;
   private Boolean firstSeen;
   private IDPResponse idpResponse;
+
+  public AuthenticationInfo(Token token, Token refreshToken, UserResponse user, Boolean firstSeen) {
+    this(token, refreshToken, user, firstSeen, null);
+  }
 }

--- a/src/main/java/com/descope/model/auth/IDPResponse.java
+++ b/src/main/java/com/descope/model/auth/IDPResponse.java
@@ -1,0 +1,16 @@
+package com.descope.model.auth;
+
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class IDPResponse {
+  private List<String> idpGroups;
+  private Map<String, Object> idpSAMLAttributes;
+  private Map<String, Object> idpOIDCClaims;
+}

--- a/src/main/java/com/descope/model/jwt/response/JWTResponse.java
+++ b/src/main/java/com/descope/model/jwt/response/JWTResponse.java
@@ -19,4 +19,10 @@ public class JWTResponse {
   private UserResponse user;
   private Boolean firstSeen;
   private IDPResponse idpResponse;
+
+  public JWTResponse(String sessionJwt, String refreshJwt, String cookieDomain, String cookiePath,
+      Integer cookieMaxAge, Integer cookieExpiration, UserResponse user, Boolean firstSeen) {
+    this(sessionJwt, refreshJwt, cookieDomain, cookiePath, cookieMaxAge, cookieExpiration, user,
+        firstSeen, null);
+  }
 }

--- a/src/main/java/com/descope/model/jwt/response/JWTResponse.java
+++ b/src/main/java/com/descope/model/jwt/response/JWTResponse.java
@@ -1,5 +1,6 @@
 package com.descope.model.jwt.response;
 
+import com.descope.model.auth.IDPResponse;
 import com.descope.model.user.response.UserResponse;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -17,4 +18,5 @@ public class JWTResponse {
   private Integer cookieExpiration;
   private UserResponse user;
   private Boolean firstSeen;
+  private IDPResponse idpResponse;
 }

--- a/src/main/java/com/descope/sdk/auth/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/com/descope/sdk/auth/impl/AuthenticationServiceImpl.java
@@ -94,7 +94,7 @@ class AuthenticationServiceImpl extends AuthenticationsBase {
     } else if (StringUtils.isNotBlank(sessionToken)) {
       try {
         Token refresh = validateAndCreateToken(refreshToken);
-        return new AuthenticationInfo(validateSessionWithToken(sessionToken), refresh, null, null);
+        return new AuthenticationInfo(validateSessionWithToken(sessionToken), refresh, null, null, null);
       } catch (Exception e) {
         if (StringUtils.isNotBlank(refreshToken)) {
           return refreshSessionWithTokenAuthenticationInfo(refreshToken);

--- a/src/main/java/com/descope/sdk/auth/impl/AuthenticationsBase.java
+++ b/src/main/java/com/descope/sdk/auth/impl/AuthenticationsBase.java
@@ -132,7 +132,8 @@ abstract class AuthenticationsBase extends SdkServicesBase implements Authentica
       refreshToken = validateAndCreateToken(jwtResponse.getRefreshJwt());
     }
     return new AuthenticationInfo(
-        sessionToken, refreshToken, jwtResponse.getUser(), jwtResponse.getFirstSeen());
+        sessionToken, refreshToken, jwtResponse.getUser(), jwtResponse.getFirstSeen(),
+        jwtResponse.getIdpResponse());
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/com/descope/sdk/mgmt/impl/JwtServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/JwtServiceImpl.java
@@ -138,7 +138,8 @@ class JwtServiceImpl extends ManagementsBase implements JwtService {
     }
     Token sessionToken = validateAndCreateToken(jwtResponse.getSessionJwt());
     Token refreshToken = validateAndCreateToken(jwtResponse.getRefreshJwt());
-    return new AuthenticationInfo(sessionToken, refreshToken, jwtResponse.getUser(), jwtResponse.getFirstSeen());
+    return new AuthenticationInfo(sessionToken, refreshToken, jwtResponse.getUser(), jwtResponse.getFirstSeen(),
+        jwtResponse.getIdpResponse());
   }
 
   private URI composeUpdateJwtUri() {

--- a/src/test/java/com/descope/sdk/TestUtils.java
+++ b/src/test/java/com/descope/sdk/TestUtils.java
@@ -62,7 +62,8 @@ public class TestUtils {
       1234567,
       1234567890,
       MOCK_USER_RESPONSE,
-      true);
+      true,
+      null);
   public static final Map<String, Object> TENANTS_AUTHZ = mapOf("permissions", Arrays.asList("tp1", "tp2"), "roles",
       Arrays.asList("tr1", "tr2"));
   public static final Token MOCK_TOKEN = Token.builder()

--- a/src/test/java/com/descope/sdk/auth/impl/OAuthServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/auth/impl/OAuthServiceImplTest.java
@@ -114,6 +114,31 @@ public class OAuthServiceImplTest {
   }
 
   @Test
+  void testExchangeTokenWithoutIDPResponse() {
+    JWTResponse jwtResponseNoIdp = new JWTResponse(
+        "someSessionJwt", "someRefreshJwt", "", "/", 1234567, 1234567890,
+        MOCK_JWT_RESPONSE.getUser(), true);
+
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(jwtResponseNoIdp).when(apiProxy).post(any(), any(), any());
+    doReturn(new SigningKeysResponse(Arrays.asList(MOCK_SIGNING_KEY))).when(apiProxy).get(any(),
+        eq(SigningKeysResponse.class));
+
+    AuthenticationInfo authenticationInfo;
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      try (MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+        mockedJwtUtils.when(() -> JwtUtils.getToken(anyString(), any())).thenReturn(MOCK_TOKEN);
+        authenticationInfo = oauthService.exchangeToken("somecode");
+      }
+    }
+
+    Assertions.assertThat(authenticationInfo).isNotNull();
+    Assertions.assertThat(authenticationInfo.getUser()).isNotNull();
+    Assertions.assertThat(authenticationInfo.getIdpResponse()).isNull();
+  }
+
+  @Test
   void testExchangeTokenWithIDPResponse() {
     IDPResponse idpResponse = new IDPResponse(
         Arrays.asList("users"),

--- a/src/test/java/com/descope/sdk/auth/impl/OAuthServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/auth/impl/OAuthServiceImplTest.java
@@ -16,9 +16,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
 import com.descope.model.auth.AuthenticationInfo;
+import com.descope.model.auth.IDPResponse;
 import com.descope.model.auth.OAuthResponse;
 import com.descope.model.client.Client;
 import com.descope.model.jwt.Token;
+import com.descope.model.jwt.response.JWTResponse;
 import com.descope.model.jwt.response.SigningKeysResponse;
 import com.descope.model.magiclink.LoginOptions;
 import com.descope.model.user.response.UserResponse;
@@ -109,6 +111,40 @@ public class OAuthServiceImplTest {
     Assertions.assertThat(user).isNotNull();
     Assertions.assertThat(user.getUserId()).isNotBlank();
     Assertions.assertThat(user.getLoginIds()).isNotEmpty();
+  }
+
+  @Test
+  void testExchangeTokenWithIDPResponse() {
+    IDPResponse idpResponse = new IDPResponse(
+        Arrays.asList("users"),
+        null,
+        mapOf("email_verified", true, "locale", "en-US"));
+    JWTResponse jwtResponseWithIdp = new JWTResponse(
+        "someSessionJwt", "someRefreshJwt", "", "/", 1234567, 1234567890,
+        MOCK_JWT_RESPONSE.getUser(), true, idpResponse);
+
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(jwtResponseWithIdp).when(apiProxy).post(any(), any(), any());
+    doReturn(new SigningKeysResponse(Arrays.asList(MOCK_SIGNING_KEY))).when(apiProxy).get(any(),
+        eq(SigningKeysResponse.class));
+
+    AuthenticationInfo authenticationInfo;
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      try (MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+        mockedJwtUtils.when(() -> JwtUtils.getToken(anyString(), any())).thenReturn(MOCK_TOKEN);
+        authenticationInfo = oauthService.exchangeToken("somecode");
+      }
+    }
+
+    Assertions.assertThat(authenticationInfo).isNotNull();
+    Assertions.assertThat(authenticationInfo.getIdpResponse()).isNotNull();
+    Assertions.assertThat(authenticationInfo.getIdpResponse().getIdpGroups())
+        .isEqualTo(Arrays.asList("users"));
+    Assertions.assertThat(authenticationInfo.getIdpResponse().getIdpSAMLAttributes()).isNull();
+    Assertions.assertThat(authenticationInfo.getIdpResponse().getIdpOIDCClaims())
+        .containsEntry("email_verified", true)
+        .containsEntry("locale", "en-US");
   }
 
   void testExampleRequireBrowser() throws Exception {

--- a/src/test/java/com/descope/sdk/auth/impl/SamlLinkServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/auth/impl/SamlLinkServiceImplTest.java
@@ -93,6 +93,32 @@ public class SamlLinkServiceImplTest {
   }
 
   @Test
+  void testExchangeTokenWithoutIDPResponse() {
+    JWTResponse jwtResponseNoIdp = new JWTResponse(
+        "someSessionJwt", "someRefreshJwt", "", "/", 1234567, 1234567890,
+        MOCK_JWT_RESPONSE.getUser(), true);
+
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(jwtResponseNoIdp).when(apiProxy).post(any(), any(), any());
+    doReturn(new SigningKeysResponse(Arrays.asList(MOCK_SIGNING_KEY)))
+        .when(apiProxy).get(any(), eq(SigningKeysResponse.class));
+
+    AuthenticationInfo authenticationInfo;
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(
+          () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      try (MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+        mockedJwtUtils.when(() -> JwtUtils.getToken(anyString(), any())).thenReturn(MOCK_TOKEN);
+        authenticationInfo = samlService.exchangeToken("somecode");
+      }
+    }
+
+    Assertions.assertThat(authenticationInfo).isNotNull();
+    Assertions.assertThat(authenticationInfo.getUser()).isNotNull();
+    Assertions.assertThat(authenticationInfo.getIdpResponse()).isNull();
+  }
+
+  @Test
   void testExchangeTokenWithIDPResponse() {
     IDPResponse idpResponse = new IDPResponse(
         Arrays.asList("engineering", "devops"),

--- a/src/test/java/com/descope/sdk/auth/impl/SamlLinkServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/auth/impl/SamlLinkServiceImplTest.java
@@ -5,6 +5,7 @@ import static com.descope.sdk.TestUtils.MOCK_SIGNING_KEY;
 import static com.descope.sdk.TestUtils.MOCK_TOKEN;
 import static com.descope.sdk.TestUtils.MOCK_URL;
 import static com.descope.sdk.TestUtils.PROJECT_ID;
+import static com.descope.utils.CollectionUtils.mapOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -13,9 +14,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
 import com.descope.model.auth.AuthenticationInfo;
+import com.descope.model.auth.IDPResponse;
 import com.descope.model.auth.SAMLResponse;
 import com.descope.model.client.Client;
 import com.descope.model.jwt.Token;
+import com.descope.model.jwt.response.JWTResponse;
 import com.descope.model.jwt.response.SigningKeysResponse;
 import com.descope.model.magiclink.LoginOptions;
 import com.descope.model.user.response.UserResponse;
@@ -87,5 +90,40 @@ public class SamlLinkServiceImplTest {
     Assertions.assertThat(user).isNotNull();
     Assertions.assertThat(user.getUserId()).isNotBlank();
     Assertions.assertThat(user.getLoginIds()).isNotEmpty();
+  }
+
+  @Test
+  void testExchangeTokenWithIDPResponse() {
+    IDPResponse idpResponse = new IDPResponse(
+        Arrays.asList("engineering", "devops"),
+        mapOf("department", "engineering", "title", "Staff Engineer"),
+        null);
+    JWTResponse jwtResponseWithIdp = new JWTResponse(
+        "someSessionJwt", "someRefreshJwt", "", "/", 1234567, 1234567890,
+        MOCK_JWT_RESPONSE.getUser(), true, idpResponse);
+
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(jwtResponseWithIdp).when(apiProxy).post(any(), any(), any());
+    doReturn(new SigningKeysResponse(Arrays.asList(MOCK_SIGNING_KEY)))
+        .when(apiProxy).get(any(), eq(SigningKeysResponse.class));
+
+    AuthenticationInfo authenticationInfo;
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(
+          () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      try (MockedStatic<JwtUtils> mockedJwtUtils = mockStatic(JwtUtils.class)) {
+        mockedJwtUtils.when(() -> JwtUtils.getToken(anyString(), any())).thenReturn(MOCK_TOKEN);
+        authenticationInfo = samlService.exchangeToken("somecode");
+      }
+    }
+
+    Assertions.assertThat(authenticationInfo).isNotNull();
+    Assertions.assertThat(authenticationInfo.getIdpResponse()).isNotNull();
+    Assertions.assertThat(authenticationInfo.getIdpResponse().getIdpGroups())
+        .isEqualTo(Arrays.asList("engineering", "devops"));
+    Assertions.assertThat(authenticationInfo.getIdpResponse().getIdpSAMLAttributes())
+        .containsEntry("department", "engineering")
+        .containsEntry("title", "Staff Engineer");
+    Assertions.assertThat(authenticationInfo.getIdpResponse().getIdpOIDCClaims()).isNull();
   }
 }


### PR DESCRIPTION
## Summary
- Add `IDPResponse` type with `idpGroups`, `idpSAMLAttributes`, and `idpOIDCClaims` fields
- Add `idpResponse` field to `AuthenticationInfo` and `JWTResponse`
- Wire through in `getAuthenticationInfo()` so SDK consumers can access IDP data after SSO token exchange

## Related PRs
- Backend: descope/descope — `feat/expose-idp-response-to-sdk`
- Go SDK: descope/go-sdk#733
- Node SDK: descope/node-sdk#721

## Test plan
- [x] Checkstyle passes
- [x] All unit tests pass
- [x] New tests: `OAuthServiceImplTest.testExchangeTokenWithIDPResponse` (OIDC claims)
- [x] New tests: `SamlLinkServiceImplTest.testExchangeTokenWithIDPResponse` (SAML attributes)

fixes: https://github.com/descope/etc/issues/15153

🤖 Generated with [Claude Code](https://claude.com/claude-code)