### PR TITLE
feat(http): also retry on transient status code 520

### DIFF
--- a/src/main/java/com/descope/proxy/impl/AbstractProxyImpl.java
+++ b/src/main/java/com/descope/proxy/impl/AbstractProxyImpl.java
@@ -36,12 +36,13 @@ abstract class AbstractProxyImpl {
 
   // HTTP status codes that should trigger automatic retries:
   // 503: Service Unavailable
+  // 520: Web Server Returned an Unknown Error (Cloudflare)
   // 521: Web Server Is Down (Cloudflare)
   // 522: Connection Timed Out (Cloudflare)
   // 524: A Timeout Occurred (Cloudflare)
   // 530: Cloudflare error
   static final Set<Integer> retryableStatusCodes = Collections.unmodifiableSet(
-      new HashSet<>(Arrays.asList(503, 521, 522, 524, 530)));
+      new HashSet<>(Arrays.asList(503, 520, 521, 522, 524, 530)));
 
   // Retry delays in milliseconds: first retry after 100ms, subsequent retries after 5000ms.
   // Package-private to allow overriding in tests.

--- a/src/test/java/com/descope/proxy/impl/AbstractProxyImplTest.java
+++ b/src/test/java/com/descope/proxy/impl/AbstractProxyImplTest.java
@@ -55,17 +55,18 @@ class AbstractProxyImplTest {
   @Test
   void testRetryStatusCodesConfig() {
     assertTrue(AbstractProxyImpl.retryableStatusCodes.contains(503));
+    assertTrue(AbstractProxyImpl.retryableStatusCodes.contains(520));
     assertTrue(AbstractProxyImpl.retryableStatusCodes.contains(521));
     assertTrue(AbstractProxyImpl.retryableStatusCodes.contains(522));
     assertTrue(AbstractProxyImpl.retryableStatusCodes.contains(524));
     assertTrue(AbstractProxyImpl.retryableStatusCodes.contains(530));
-    assertEquals(5, AbstractProxyImpl.retryableStatusCodes.size());
+    assertEquals(6, AbstractProxyImpl.retryableStatusCodes.size());
   }
 
   @Test
   @SuppressWarnings({"unchecked", "rawtypes"})
   void testRetryOnRetryableStatusCodes() throws IOException {
-    List<Integer> retryableCodes = Arrays.asList(503, 521, 522, 524, 530);
+    List<Integer> retryableCodes = Arrays.asList(503, 520, 521, 522, 524, 530);
     for (int statusCode : retryableCodes) {
       AtomicInteger callCount = new AtomicInteger(0);
       CloseableHttpClient mockClient = mock(CloseableHttpClient.class);


### PR DESCRIPTION
## Summary

Add Cloudflare status code `520` ("Web Server Returned an Unknown Error") to the HTTP client's retryable status codes, alongside the existing `503` / `521` / `522` / `524` / `530`.

Like the other Cloudflare 52x codes already retried, `520` is a transient edge error returned when the origin is briefly unreachable (e.g. during pod replacement on deploy), so the request is safe to retry. Follow-up to #302; brings this SDK in line with go-sdk (descope/go-sdk#775), python-sdk (descope/python-sdk#1581) and core-js-sdk (descope/descope-js#1423).

https://github.com/descope/etc/issues/14039

## Test plan

- [x] Added `520` to the retryable-status-codes test/data set, mirroring the existing per-code coverage
- [ ] CI runs the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)