### PR TITLE
feat(mgmt): add java sdk parity methods and models to match go sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,13 @@ try {
 } catch (DescopeException de) {
     // Handle the error
 }
+
+// Update the default roles applied to users of the tenant
+try {
+    ts.updateDefaultRoles("my-custom-id", Arrays.asList("Tenant Admin"));
+} catch (DescopeException de) {
+    // Handle the error
+}
 ```
 
 ### Manage Users
@@ -793,6 +800,37 @@ try {
     for (AllUsersResponsibleDetails u : users) {
         // Do something
     }
+}
+
+// Delete multiple users at once by their user IDs
+try {
+    us.deleteBatch(Arrays.asList("<user-id-1>", "<user-id-2>"));
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+// Update a user's recovery email / phone
+try {
+    us.updateRecoveryEmail("desmond@descope.com", "recovery@descope.com", true);
+    us.updateRecoveryPhone("desmond@descope.com", "+1234567890", true);
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+// Manage a user's passkeys (WebAuthn credentials)
+try {
+    List<UserPasskey> passkeys = us.listPasskeys("desmond@descope.com");
+    us.removePasskey("desmond@descope.com", "<credential-id>");
+    us.removeAllPasskeys("desmond@descope.com");
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+// Remove a user's TOTP seed (forces re-enrollment)
+try {
+    us.removeTOTPSeed("desmond@descope.com");
+} catch (DescopeException de) {
+    // Handle the error
 }
 
 ```
@@ -902,6 +940,22 @@ try {
     // Handle the error
 }
 
+// Rotate an access key - the previous cleartext becomes invalid and a new one is returned.
+try {
+    AccessKeyResponse resp = aks.rotate("access-key-1");
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+// Batch operations on multiple access keys at once.
+try {
+    aks.activateBatch(Arrays.asList("access-key-1", "access-key-2"));
+    aks.deactivateBatch(Arrays.asList("access-key-1", "access-key-2"));
+    aks.deleteBatch(Arrays.asList("access-key-1", "access-key-2"));
+} catch (DescopeException de) {
+    // Handle the error
+}
+
 ```
 
 ### Manage SSO Setting
@@ -1003,6 +1057,20 @@ try {
 } catch (DescopeException de) {
     // Handle the error
 }
+
+// Configure the SAML/OAuth redirect URLs used after SSO authentication
+try {
+    ss.configureSSORedirectURL(tenantId, "https://my-app.com/handle-saml", "https://my-app.com/handle-oauth", "sso-config-id");
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+// Recalculate the role/attribute mappings for a tenant's SSO configuration
+try {
+    ss.recalculateSSOMappings(tenantId, "sso-config-id");
+} catch (DescopeException de) {
+    // Handle the error
+}
 ```
 
 ### Manage Permissions
@@ -1045,6 +1113,30 @@ try {
     for (Permission p : resp.getPermissions()) {
         // Do something
     }
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+// Create several permissions in a single request
+try {
+    ps.createBatch(Arrays.asList(
+        Permission.builder().name("Permission A").description("desc A").build(),
+        Permission.builder().name("Permission B").build()));
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+// Update or delete a permission by its ID (useful when renaming)
+try {
+    ps.updateWithId("<permission-id>", "My Updated Permission", "A revised description");
+    ps.deleteWithId("<permission-id>");
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+// Delete multiple permissions at once, by name and/or by ID
+try {
+    ps.deleteBatch(Arrays.asList("Permission A"), Arrays.asList("<permission-id>"));
 } catch (DescopeException de) {
     // Handle the error
 }
@@ -1105,6 +1197,13 @@ try {
     for (Role r : resp.getRoles()) {
         // Do something
     }
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+// Delete a role by its ID (pass the tenant ID for tenant-scoped roles, or "" for project roles)
+try {
+    rs.deleteWithId("<role-id>", "tenant-id");
 } catch (DescopeException de) {
     // Handle the error
 }
@@ -1208,6 +1307,13 @@ try {
     // Handle the error
 }
 
+// Delete flows by their IDs
+try {
+    fs.deleteFlows(Arrays.asList("sign-up", "sign-in"));
+} catch (DescopeException de) {
+    // Handle the error
+}
+
 ```
 
 ### Manage JWTs
@@ -1281,6 +1387,23 @@ try {
 }
 ```
 
+Impersonate another user (the impersonator must have permission to do so). `stopImpersonation` returns
+a regular JWT for the original impersonator.
+
+```java
+JwtService jwtService = descopeClient.getManagementServices().getJwtService();
+try {
+    String jwt = jwtService.impersonate("impersonator-id", "target-login-id", true,
+            new HashMap<String, Object>() {{ put("custom-key1", "custom-value1"); }}, "tenant-id");
+    // Step-up impersonation (requires an existing session)
+    String stepupJwt = jwtService.impersonateStepup("impersonator-id", "target-login-id", true, null, "tenant-id");
+    // Return to the original user
+    String originalJwt = jwtService.stopImpersonation(jwt, null, "tenant-id");
+} catch (DescopeException de) {
+    // Handle the error
+}
+```
+
 ### Audit
 
 You can perform an audit search for either specific values or full-text across the fields. Audit search is limited to the last 30 days.
@@ -1314,6 +1437,19 @@ try {
             .actorId("some-actor-id")
             .type(AuditType.INFO)
             .action("some-action-name")
+            .build());
+} catch (DescopeException de) {
+    // Handle the error
+}
+```
+
+You can also configure an audit webhook connector that streams audit events to an external endpoint:
+
+```java
+try {
+    as.createAuditWebhook(AuditWebhook.builder()
+            .name("My Audit Webhook")
+            .url("https://my-app.com/audit-hook")
             .build());
 } catch (DescopeException de) {
     // Handle the error
@@ -1650,6 +1786,20 @@ try {
 // Note that this action is supported only with a pro license or above.
 try {
     NewProjectResponse resp = ps.cloneProject("New Project Name", ProjectTag.None);
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+// Update the project's tags
+try {
+    ps.updateTags(Arrays.asList("production", "eu"));
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+// Delete the current project. This action is irreversible - use carefully.
+try {
+    ps.deleteProject();
 } catch (DescopeException de) {
     // Handle the error
 }

--- a/README.md
+++ b/README.md
@@ -1134,6 +1134,14 @@ try {
     // Handle the error
 }
 
+// Update several permissions in a single request
+try {
+    ps.updateBatch(Arrays.asList(
+        PermissionUpdateRequest.builder().id("<permission-id>").newName("Renamed").description("desc").build()));
+} catch (DescopeException de) {
+    // Handle the error
+}
+
 // Delete multiple permissions at once, by name and/or by ID
 try {
     ps.deleteBatch(Arrays.asList("Permission A"), Arrays.asList("<permission-id>"));
@@ -1204,6 +1212,17 @@ try {
 // Delete a role by its ID (pass the tenant ID for tenant-scoped roles, or "" for project roles)
 try {
     rs.deleteWithId("<role-id>", "tenant-id");
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+// Create, update or delete several roles in a single request
+try {
+    RoleResponse created = rs.createBatch(Arrays.asList(
+        Role.builder().name("Role A").description("desc A").build()));
+    RoleResponse updated = rs.updateBatch(Arrays.asList(
+        RoleUpdateRequest.builder().name("Role A").newName("Role A Renamed").build()));
+    rs.deleteBatch(Arrays.asList("Role A Renamed"), "", null);
 } catch (DescopeException de) {
     // Handle the error
 }
@@ -1793,6 +1812,13 @@ try {
 // Update the project's tags
 try {
     ps.updateTags(Arrays.asList("production", "eu"));
+} catch (DescopeException de) {
+    // Handle the error
+}
+
+// List all projects in the current company
+try {
+    List<Project> projects = ps.listProjects();
 } catch (DescopeException de) {
     // Handle the error
 }

--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -299,12 +299,19 @@ public class Routes {
 
     // Permission batch (parity)
     public static final String MANAGEMENT_PERMISSION_CREATE_BATCH_LINK = "/v1/mgmt/permission/create/batch";
+    public static final String MANAGEMENT_PERMISSION_UPDATE_BATCH_LINK = "/v1/mgmt/permission/update/batch";
     public static final String MANAGEMENT_PERMISSION_DELETE_BATCH_LINK = "/v1/mgmt/permission/delete/batch";
+
+    // Role batch (parity)
+    public static final String MANAGEMENT_ROLES_CREATE_BATCH_LINK = "/v1/mgmt/role/create/batch";
+    public static final String MANAGEMENT_ROLES_UPDATE_BATCH_LINK = "/v1/mgmt/role/update/batch";
+    public static final String MANAGEMENT_ROLES_DELETE_BATCH_LINK = "/v1/mgmt/role/delete/batch";
 
     // Flow (parity)
     public static final String FLOW_DELETE_LINK = "/v1/mgmt/flow/delete";
 
     // Project (parity)
+    public static final String MANAGEMENT_PROJECT_LIST = "/v1/mgmt/projects/list";
     public static final String MANAGEMENT_PROJECT_UPDATE_TAGS = "/v1/mgmt/project/update/tags";
     public static final String MANAGEMENT_PROJECT_DELETE = "/v1/mgmt/project/delete";
 

--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -299,19 +299,12 @@ public class Routes {
 
     // Permission batch (parity)
     public static final String MANAGEMENT_PERMISSION_CREATE_BATCH_LINK = "/v1/mgmt/permission/create/batch";
-    public static final String MANAGEMENT_PERMISSION_UPDATE_BATCH_LINK = "/v1/mgmt/permission/update/batch";
     public static final String MANAGEMENT_PERMISSION_DELETE_BATCH_LINK = "/v1/mgmt/permission/delete/batch";
-
-    // Role batch (parity)
-    public static final String MANAGEMENT_ROLES_CREATE_BATCH_LINK = "/v1/mgmt/role/create/batch";
-    public static final String MANAGEMENT_ROLES_UPDATE_BATCH_LINK = "/v1/mgmt/role/update/batch";
-    public static final String MANAGEMENT_ROLES_DELETE_BATCH_LINK = "/v1/mgmt/role/delete/batch";
 
     // Flow (parity)
     public static final String FLOW_DELETE_LINK = "/v1/mgmt/flow/delete";
 
     // Project (parity)
-    public static final String MANAGEMENT_PROJECT_LIST = "/v1/mgmt/projects/list";
     public static final String MANAGEMENT_PROJECT_UPDATE_TAGS = "/v1/mgmt/project/update/tags";
     public static final String MANAGEMENT_PROJECT_DELETE = "/v1/mgmt/project/delete";
 

--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -274,5 +274,57 @@ public class Routes {
     public static final String MANAGEMENT_INBOUND_DELETE_CONSENT = "/v1/mgmt/thirdparty/consents/delete";
     public static final String MANAGEMENT_INBOUND_DELETE_TENANT_CONSENT = "/v1/mgmt/thirdparty/consents/delete/tenant";
     public static final String MANAGEMENT_INBOUND_SEARCH_CONSENT = "/v1/mgmt/thirdparty/consents/search";
+
+    // Tenant (parity)
+    public static final String TENANT_UPDATE_DEFAULT_ROLES_LINK = "/v1/mgmt/tenant/updateDefaultRoles";
+
+    // SSO Application (parity)
+    public static final String SSO_APPLICATION_SECRET_LINK = "/v1/mgmt/sso/idp/app/secret";
+    public static final String SSO_APPLICATION_ROTATE_LINK = "/v1/mgmt/sso/idp/app/rotate";
+
+    // SSO settings (parity)
+    public static final String SSO_REDIRECT_URL_LINK = "/v1/mgmt/sso/redirect";
+    public static final String SSO_RECALCULATE_MAPPINGS_LINK = "/v1/mgmt/sso/recalculate-mappings";
+
+    // JWT impersonation (parity)
+    public static final String IMPERSONATE_LINK = "/v1/mgmt/impersonate";
+    public static final String IMPERSONATE_STEPUP_LINK = "/v1/mgmt/impersonate/stepup";
+    public static final String STOP_IMPERSONATION_LINK = "/v1/mgmt/stop/impersonation";
+
+    // Access key batch + rotate (parity)
+    public static final String MANAGEMENT_ACCESS_KEY_ACTIVATE_BATCH_LINK = "/v1/mgmt/accesskey/activate/batch";
+    public static final String MANAGEMENT_ACCESS_KEY_DEACTIVATE_BATCH_LINK = "/v1/mgmt/accesskey/deactivate/batch";
+    public static final String MANAGEMENT_ACCESS_KEY_DELETE_BATCH_LINK = "/v1/mgmt/accesskey/delete/batch";
+    public static final String MANAGEMENT_ACCESS_KEY_ROTATE_LINK = "/v1/mgmt/accesskey/rotate";
+
+    // Permission batch (parity)
+    public static final String MANAGEMENT_PERMISSION_CREATE_BATCH_LINK = "/v1/mgmt/permission/create/batch";
+    public static final String MANAGEMENT_PERMISSION_UPDATE_BATCH_LINK = "/v1/mgmt/permission/update/batch";
+    public static final String MANAGEMENT_PERMISSION_DELETE_BATCH_LINK = "/v1/mgmt/permission/delete/batch";
+
+    // Role batch (parity)
+    public static final String MANAGEMENT_ROLES_CREATE_BATCH_LINK = "/v1/mgmt/role/create/batch";
+    public static final String MANAGEMENT_ROLES_UPDATE_BATCH_LINK = "/v1/mgmt/role/update/batch";
+    public static final String MANAGEMENT_ROLES_DELETE_BATCH_LINK = "/v1/mgmt/role/delete/batch";
+
+    // Flow (parity)
+    public static final String FLOW_DELETE_LINK = "/v1/mgmt/flow/delete";
+
+    // Project (parity)
+    public static final String MANAGEMENT_PROJECT_LIST = "/v1/mgmt/projects/list";
+    public static final String MANAGEMENT_PROJECT_UPDATE_TAGS = "/v1/mgmt/project/update/tags";
+    public static final String MANAGEMENT_PROJECT_DELETE = "/v1/mgmt/project/delete";
+
+    // Audit (parity)
+    public static final String MANAGEMENT_AUDIT_WEBHOOK_CREATE = "/v1/mgmt/connector/audit/web/set";
+
+    // User (parity)
+    public static final String USER_DELETE_BATCH_LINK = "/v1/mgmt/user/delete/batch";
+    public static final String USER_UPDATE_RECOVERY_EMAIL_LINK = "/v1/mgmt/user/update/recovery/email";
+    public static final String USER_UPDATE_RECOVERY_PHONE_LINK = "/v1/mgmt/user/update/recovery/phone";
+    public static final String USER_REMOVE_ALL_PASSKEYS_LINK = "/v1/mgmt/user/passkeys/delete";
+    public static final String USER_REMOVE_PASSKEY_LINK = "/v1/mgmt/user/passkey/delete";
+    public static final String USER_LIST_PASSKEYS_LINK = "/v1/mgmt/user/passkeys/list";
+    public static final String USER_REMOVE_TOTP_SEED_LINK = "/v1/mgmt/user/totp/delete";
   }
 }

--- a/src/main/java/com/descope/model/audit/AuditWebhook.java
+++ b/src/main/java/com/descope/model/audit/AuditWebhook.java
@@ -1,0 +1,25 @@
+package com.descope.model.audit;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AuditWebhook {
+  String name;
+  String description;
+  String url;
+  AuditWebhookAuthentication authentication;
+  String hmacSecret;
+  Map<String, String> headers;
+  boolean insecure;
+  List<AuditWebhookFilter> filters;
+}

--- a/src/main/java/com/descope/model/audit/AuditWebhookApiKeyAuthentication.java
+++ b/src/main/java/com/descope/model/audit/AuditWebhookApiKeyAuthentication.java
@@ -1,0 +1,17 @@
+package com.descope.model.audit;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AuditWebhookApiKeyAuthentication {
+  String key;
+  String token;
+}

--- a/src/main/java/com/descope/model/audit/AuditWebhookAuthentication.java
+++ b/src/main/java/com/descope/model/audit/AuditWebhookAuthentication.java
@@ -1,0 +1,18 @@
+package com.descope.model.audit;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AuditWebhookAuthentication {
+  String bearerToken;
+  AuditWebhookBasicAuthentication basic;
+  AuditWebhookApiKeyAuthentication apiKey;
+}

--- a/src/main/java/com/descope/model/audit/AuditWebhookBasicAuthentication.java
+++ b/src/main/java/com/descope/model/audit/AuditWebhookBasicAuthentication.java
@@ -1,0 +1,17 @@
+package com.descope.model.audit;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AuditWebhookBasicAuthentication {
+  String username;
+  String password;
+}

--- a/src/main/java/com/descope/model/audit/AuditWebhookFilter.java
+++ b/src/main/java/com/descope/model/audit/AuditWebhookFilter.java
@@ -1,0 +1,19 @@
+package com.descope.model.audit;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AuditWebhookFilter {
+  String filterType;
+  String operator;
+  List<String> values;
+}

--- a/src/main/java/com/descope/model/permission/PermissionUpdateRequest.java
+++ b/src/main/java/com/descope/model/permission/PermissionUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.descope.model.permission;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PermissionUpdateRequest {
+  private String name;
+  private String id;
+  private String newName;
+  private String description;
+}

--- a/src/main/java/com/descope/model/project/Project.java
+++ b/src/main/java/com/descope/model/project/Project.java
@@ -1,0 +1,18 @@
+package com.descope.model.project;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Project {
+  private String id;
+  private String name;
+  private String environment;
+  private List<String> tags;
+}

--- a/src/main/java/com/descope/model/project/ProjectsResponse.java
+++ b/src/main/java/com/descope/model/project/ProjectsResponse.java
@@ -1,0 +1,15 @@
+package com.descope.model.project;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectsResponse {
+  private List<Project> projects;
+}

--- a/src/main/java/com/descope/model/roles/RoleUpdateRequest.java
+++ b/src/main/java/com/descope/model/roles/RoleUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.descope.model.roles;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RoleUpdateRequest {
+  private String name;
+  private String id;
+  private String newName;
+  private String description;
+  private List<String> permissionNames;
+  private String tenantId;
+}

--- a/src/main/java/com/descope/model/ssoapp/SSOApplicationSecretResponse.java
+++ b/src/main/java/com/descope/model/ssoapp/SSOApplicationSecretResponse.java
@@ -1,0 +1,14 @@
+package com.descope.model.ssoapp;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SSOApplicationSecretResponse {
+  private String cleartext;
+}

--- a/src/main/java/com/descope/model/user/response/UserPasskey.java
+++ b/src/main/java/com/descope/model/user/response/UserPasskey.java
@@ -1,0 +1,19 @@
+package com.descope.model.user.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a registered passkey (WebAuthn credential) for a user.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserPasskey {
+  String id;
+  String rpId;
+  String kind;
+  String displayName;
+  Integer createdTime;
+}

--- a/src/main/java/com/descope/model/user/response/UserPasskeysResponse.java
+++ b/src/main/java/com/descope/model/user/response/UserPasskeysResponse.java
@@ -1,0 +1,16 @@
+package com.descope.model.user.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Wrapper for the response of listing a user's registered passkeys.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserPasskeysResponse {
+  List<UserPasskey> passkeys;
+}

--- a/src/main/java/com/descope/sdk/mgmt/AccessKeyService.java
+++ b/src/main/java/com/descope/sdk/mgmt/AccessKeyService.java
@@ -38,4 +38,37 @@ public interface AccessKeyService {
   AccessKeyResponse activate(String id) throws DescopeException;
 
   void delete(String id) throws DescopeException;
+
+  /**
+   * Rotate an access key, invalidating the current cleartext and generating a new one.
+   *
+   * @param id - The access key ID to rotate
+   * @return {@link AccessKeyResponse} containing the updated details and the new cleartext
+   * @throws DescopeException in case of errors
+   */
+  AccessKeyResponse rotate(String id) throws DescopeException;
+
+  /**
+   * Deactivate multiple access keys in a single request.
+   *
+   * @param ids - The list of access key IDs to deactivate
+   * @throws DescopeException in case of errors
+   */
+  void deactivateBatch(List<String> ids) throws DescopeException;
+
+  /**
+   * Activate multiple access keys in a single request.
+   *
+   * @param ids - The list of access key IDs to activate
+   * @throws DescopeException in case of errors
+   */
+  void activateBatch(List<String> ids) throws DescopeException;
+
+  /**
+   * Delete multiple access keys in a single request.
+   *
+   * @param ids - The list of access key IDs to delete
+   * @throws DescopeException in case of errors
+   */
+  void deleteBatch(List<String> ids) throws DescopeException;
 }

--- a/src/main/java/com/descope/sdk/mgmt/AuditService.java
+++ b/src/main/java/com/descope/sdk/mgmt/AuditService.java
@@ -4,6 +4,7 @@ import com.descope.exception.DescopeException;
 import com.descope.model.audit.AuditCreateRequest;
 import com.descope.model.audit.AuditSearchRequest;
 import com.descope.model.audit.AuditSearchResponse;
+import com.descope.model.audit.AuditWebhook;
 
 /** Provides audit records search capabilities. */
 public interface AuditService {
@@ -24,4 +25,12 @@ public interface AuditService {
    * @throws DescopeException If there occurs any exception, a subtype of this exception will be thrown.
    */
   void createEvent(AuditCreateRequest request) throws DescopeException;
+
+  /**
+   * Create an audit webhook.
+   *
+   * @param webhook the audit webhook configuration; must be non-null and have a name.
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be thrown.
+   */
+  void createAuditWebhook(AuditWebhook webhook) throws DescopeException;
 }

--- a/src/main/java/com/descope/sdk/mgmt/FlowService.java
+++ b/src/main/java/com/descope/sdk/mgmt/FlowService.java
@@ -12,6 +12,14 @@ public interface FlowService {
   
   FlowsResponse listFlows() throws DescopeException;
 
+  /**
+   * Delete flows by their IDs.
+   *
+   * @param flowIds The IDs of the flows to delete
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be thrown.
+   */
+  void deleteFlows(List<String> flowIds) throws DescopeException;
+
   FlowResponse exportFlow(String flowID) throws DescopeException;
 
   FlowResponse importFlow(String flowID, Flow flow, List<Screen> screens) throws DescopeException;

--- a/src/main/java/com/descope/sdk/mgmt/JwtService.java
+++ b/src/main/java/com/descope/sdk/mgmt/JwtService.java
@@ -50,4 +50,45 @@ public interface JwtService {
   ClientAssertionResponse generateClientAssertionJwt(String issuer, String subject,
       List<String> audience, Integer expiresIn, Boolean flattenAudience, String algorithm)
       throws DescopeException;
+
+  /**
+   * Impersonate another user. The impersonator user must have the requested permission
+   * otherwise the operation will fail. A new JWT for the impersonated user will be returned.
+   *
+   * @param impersonatorId  - The ID of the impersonator (a valid login ID or user ID)
+   * @param loginId         - The login ID of the user to impersonate
+   * @param validateConsent - Whether to validate that consent to impersonation was given
+   * @param customClaims    - Custom claims to add to the impersonated JWT (optional)
+   * @param tenantId        - The tenant to select for the impersonated user (optional)
+   * @return - New JWT for the impersonated user
+   */
+  String impersonate(String impersonatorId, String loginId, boolean validateConsent,
+      Map<String, Object> customClaims, String tenantId) throws DescopeException;
+
+  /**
+   * Impersonate another user with a step-up JWT. The impersonator user must have the requested
+   * permission otherwise the operation will fail. A new JWT for the impersonated user will be
+   * returned.
+   *
+   * @param impersonatorId  - The ID of the impersonator (a valid login ID or user ID)
+   * @param loginId         - The login ID of the user to impersonate
+   * @param validateConsent - Whether to validate that consent to impersonation was given
+   * @param customClaims    - Custom claims to add to the impersonated JWT (optional)
+   * @param tenantId        - The tenant to select for the impersonated user (optional)
+   * @return - New step-up JWT for the impersonated user
+   */
+  String impersonateStepup(String impersonatorId, String loginId, boolean validateConsent,
+      Map<String, Object> customClaims, String tenantId) throws DescopeException;
+
+  /**
+   * Stop an active impersonation given the impersonated user's JWT. A new JWT for the original
+   * (impersonator) user will be returned.
+   *
+   * @param jwt          - The impersonated user's JWT
+   * @param customClaims - Custom claims to add to the returned JWT (optional)
+   * @param tenantId     - The tenant to select for the returned JWT (optional)
+   * @return - New JWT for the original impersonator user
+   */
+  String stopImpersonation(String jwt, Map<String, Object> customClaims, String tenantId)
+      throws DescopeException;
 }

--- a/src/main/java/com/descope/sdk/mgmt/PermissionService.java
+++ b/src/main/java/com/descope/sdk/mgmt/PermissionService.java
@@ -1,14 +1,47 @@
 package com.descope.sdk.mgmt;
 
 import com.descope.exception.DescopeException;
+import com.descope.model.permission.Permission;
 import com.descope.model.permission.PermissionResponse;
+import java.util.List;
 
 public interface PermissionService {
   void create(String name, String description) throws DescopeException;
 
+  /**
+   * Create multiple permissions in a single batch.
+   *
+   * @param permissions - The permissions to create
+   */
+  void createBatch(List<Permission> permissions) throws DescopeException;
+
   void update(String name, String newName, String description) throws DescopeException;
 
+  /**
+   * Update an existing permission identified by its ID.
+   *
+   * @param id          - The ID of the permission to update
+   * @param newName     - The new name for the permission
+   * @param description - The new description for the permission (optional)
+   */
+  void updateWithId(String id, String newName, String description) throws DescopeException;
+
   void delete(String name) throws DescopeException;
+
+  /**
+   * Delete an existing permission identified by its ID.
+   *
+   * @param id - The ID of the permission to delete
+   */
+  void deleteWithId(String id) throws DescopeException;
+
+  /**
+   * Delete multiple permissions identified by their names and/or IDs.
+   *
+   * @param names - The names of the permissions to delete (optional)
+   * @param ids   - The IDs of the permissions to delete (optional)
+   */
+  void deleteBatch(List<String> names, List<String> ids) throws DescopeException;
 
   PermissionResponse loadAll() throws DescopeException;
 }

--- a/src/main/java/com/descope/sdk/mgmt/PermissionService.java
+++ b/src/main/java/com/descope/sdk/mgmt/PermissionService.java
@@ -3,6 +3,7 @@ package com.descope.sdk.mgmt;
 import com.descope.exception.DescopeException;
 import com.descope.model.permission.Permission;
 import com.descope.model.permission.PermissionResponse;
+import com.descope.model.permission.PermissionUpdateRequest;
 import java.util.List;
 
 public interface PermissionService {
@@ -25,6 +26,13 @@ public interface PermissionService {
    * @param description - The new description for the permission (optional)
    */
   void updateWithId(String id, String newName, String description) throws DescopeException;
+
+  /**
+   * Update multiple permissions in a single batch.
+   *
+   * @param permissions - The permissions to update
+   */
+  void updateBatch(List<PermissionUpdateRequest> permissions) throws DescopeException;
 
   void delete(String name) throws DescopeException;
 

--- a/src/main/java/com/descope/sdk/mgmt/ProjectService.java
+++ b/src/main/java/com/descope/sdk/mgmt/ProjectService.java
@@ -4,6 +4,7 @@ import com.descope.enums.ProjectTag;
 import com.descope.exception.DescopeException;
 import com.descope.model.project.ExportProjectResponse;
 import com.descope.model.project.NewProjectResponse;
+import com.descope.model.project.Project;
 import java.util.List;
 import java.util.Map;
 
@@ -64,4 +65,12 @@ public interface ProjectService {
    * @throws DescopeException - error upon failure
    */
   void deleteProject() throws DescopeException;
+
+  /**
+   * List all projects in the current company.
+   *
+   * @return the list of projects
+   * @throws DescopeException - error upon failure
+   */
+  List<Project> listProjects() throws DescopeException;
 }

--- a/src/main/java/com/descope/sdk/mgmt/ProjectService.java
+++ b/src/main/java/com/descope/sdk/mgmt/ProjectService.java
@@ -4,6 +4,7 @@ import com.descope.enums.ProjectTag;
 import com.descope.exception.DescopeException;
 import com.descope.model.project.ExportProjectResponse;
 import com.descope.model.project.NewProjectResponse;
+import java.util.List;
 import java.util.Map;
 
 public interface ProjectService {
@@ -48,4 +49,19 @@ public interface ProjectService {
    * @param files The raw JSON dictionary of files, in the same format as the one returned by calls to export.
    */
   void importProject(Map<String, Object> files) throws DescopeException;
+
+  /**
+   * Update the current project tags.
+   *
+   * @param tags The new tags for the project
+   * @throws DescopeException - error upon failure
+   */
+  void updateTags(List<String> tags) throws DescopeException;
+
+  /**
+   * Delete the current project.
+   *
+   * @throws DescopeException - error upon failure
+   */
+  void deleteProject() throws DescopeException;
 }

--- a/src/main/java/com/descope/sdk/mgmt/RolesService.java
+++ b/src/main/java/com/descope/sdk/mgmt/RolesService.java
@@ -1,8 +1,10 @@
 package com.descope.sdk.mgmt;
 
 import com.descope.exception.DescopeException;
+import com.descope.model.roles.Role;
 import com.descope.model.roles.RoleResponse;
 import com.descope.model.roles.RoleSearchOptions;
+import com.descope.model.roles.RoleUpdateRequest;
 import java.util.List;
 
 public interface RolesService {
@@ -11,10 +13,26 @@ public interface RolesService {
 
   void create(String name, String tenantId, String description, List<String> permissionNames) throws DescopeException;
 
+  /**
+   * Create multiple roles in a single batch.
+   *
+   * @param roles - The roles to create
+   * @return {@link RoleResponse RoleResponse} containing the created roles
+   */
+  RoleResponse createBatch(List<Role> roles) throws DescopeException;
+
   void update(String name, String newName, String description, List<String> permissionNames) throws DescopeException;
 
   void update(String name, String tenantId, String newName, String description, List<String> permissionNames)
       throws DescopeException;
+
+  /**
+   * Update multiple roles in a single batch.
+   *
+   * @param roles - The roles to update
+   * @return {@link RoleResponse RoleResponse} containing the updated roles
+   */
+  RoleResponse updateBatch(List<RoleUpdateRequest> roles) throws DescopeException;
 
   void delete(String name) throws DescopeException;
 
@@ -27,6 +45,15 @@ public interface RolesService {
    * @param tenantId - The tenant the role belongs to (optional)
    */
   void deleteWithId(String id, String tenantId) throws DescopeException;
+
+  /**
+   * Delete multiple roles identified by their names and/or IDs.
+   *
+   * @param roleNames - The names of the roles to delete (optional)
+   * @param tenantId  - The tenant the roles belong to (optional)
+   * @param roleIds   - The IDs of the roles to delete (optional)
+   */
+  void deleteBatch(List<String> roleNames, String tenantId, List<String> roleIds) throws DescopeException;
 
   RoleResponse loadAll() throws DescopeException;
 

--- a/src/main/java/com/descope/sdk/mgmt/RolesService.java
+++ b/src/main/java/com/descope/sdk/mgmt/RolesService.java
@@ -20,6 +20,14 @@ public interface RolesService {
 
   void delete(String name, String tenantId) throws DescopeException;
 
+  /**
+   * Delete an existing role identified by its ID.
+   *
+   * @param id       - The ID of the role to delete
+   * @param tenantId - The tenant the role belongs to (optional)
+   */
+  void deleteWithId(String id, String tenantId) throws DescopeException;
+
   RoleResponse loadAll() throws DescopeException;
 
   RoleResponse search(RoleSearchOptions roleSearchOptions) throws DescopeException;

--- a/src/main/java/com/descope/sdk/mgmt/SsoApplicationService.java
+++ b/src/main/java/com/descope/sdk/mgmt/SsoApplicationService.java
@@ -69,4 +69,22 @@ public interface SsoApplicationService {
    * @throws DescopeException If error, a subtype of this exception will be thrown
    */
   List<SSOApplication> loadAll() throws DescopeException;
+
+  /**
+   * Get the cleartext secret of an sso application by id.
+   *
+   * @param id ID of the application to get the secret for
+   * @return the cleartext application secret
+   * @throws DescopeException If error, a subtype of this exception will be thrown
+   */
+  String getApplicationSecret(String id) throws DescopeException;
+
+  /**
+   * Rotate the secret of an sso application by id and return the new cleartext secret.
+   *
+   * @param id ID of the application to rotate the secret for
+   * @return the rotated cleartext application secret
+   * @throws DescopeException If error, a subtype of this exception will be thrown
+   */
+  String rotateApplicationSecret(String id) throws DescopeException;
 }

--- a/src/main/java/com/descope/sdk/mgmt/SsoService.java
+++ b/src/main/java/com/descope/sdk/mgmt/SsoService.java
@@ -83,6 +83,27 @@ public interface SsoService {
    */
   void deleteSettings(String tenantId) throws DescopeException;
 
+  /**
+   * Configure the URLs to redirect to after a successful SSO authentication for the given tenant.
+   *
+   * @param tenantId required tenant ID
+   * @param samlRedirectUrl optional URL to redirect to after a SAML SSO authentication
+   * @param oauthRedirectUrl optional URL to redirect to after an OIDC/OAuth SSO authentication
+   * @param ssoId optional SSO configuration ID
+   * @throws DescopeException If error, a subtype of this exception will be thrown
+   */
+  void configureSSORedirectURL(String tenantId, String samlRedirectUrl, String oauthRedirectUrl, String ssoId)
+      throws DescopeException;
+
+  /**
+   * Recalculate the SSO mappings (role and attribute mappings) for the given tenant.
+   *
+   * @param tenantId required tenant ID
+   * @param ssoId optional SSO configuration ID
+   * @throws DescopeException If error, a subtype of this exception will be thrown
+   */
+  void recalculateSSOMappings(String tenantId, String ssoId) throws DescopeException;
+
   @Deprecated
   SSOSettingsResponse getSettings(String tenantID) throws DescopeException;
 

--- a/src/main/java/com/descope/sdk/mgmt/TenantService.java
+++ b/src/main/java/com/descope/sdk/mgmt/TenantService.java
@@ -184,4 +184,13 @@ public interface TenantService {
    * @throws DescopeException in case of errors
    */
   void revokeSSOConfigurationLink(String tenantId, String ssoID) throws DescopeException;
+
+  /**
+   * Update the default roles for the tenant.
+   *
+   * @param tenantId     Tenant ID
+   * @param defaultRoles The list of default roles to set for the tenant
+   * @throws DescopeException in case of errors
+   */
+  void updateDefaultRoles(String tenantId, List<String> defaultRoles) throws DescopeException;
 }

--- a/src/main/java/com/descope/sdk/mgmt/UserService.java
+++ b/src/main/java/com/descope/sdk/mgmt/UserService.java
@@ -15,6 +15,7 @@ import com.descope.model.user.response.MagicLinkTestUserResponse;
 import com.descope.model.user.response.OTPTestUserResponse;
 import com.descope.model.user.response.ProviderTokenResponse;
 import com.descope.model.user.response.UserHistoryResponse;
+import com.descope.model.user.response.UserPasskey;
 import com.descope.model.user.response.UserResponseDetails;
 import com.descope.model.user.response.UsersBatchResponse;
 import java.util.List;
@@ -605,4 +606,78 @@ public interface UserService {
    *     thrown.
    */
   List<UserHistoryResponse> history(List<String> userIds) throws DescopeException;
+
+  /**
+   * Delete multiple users, by the given user IDs.
+   *
+   * @param userIds List of user IDs to delete. The list must not be empty.
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be
+   *     thrown.
+   */
+  void deleteBatch(List<String> userIds) throws DescopeException;
+
+  /**
+   * Remove the TOTP seed for the user with the given login ID.
+   *
+   * @param loginId The loginID is required.
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be
+   *     thrown.
+   */
+  void removeTOTPSeed(String loginId) throws DescopeException;
+
+  /**
+   * Remove all registered passkeys (WebAuthn devices) for the user with the given login ID.
+   *
+   * @param loginId The loginID is required.
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be
+   *     thrown.
+   */
+  void removeAllPasskeys(String loginId) throws DescopeException;
+
+  /**
+   * Remove a single registered passkey, identified by its credential ID, for the user with the
+   * given login ID.
+   *
+   * @param loginId The loginID is required.
+   * @param credentialId The credential ID of the passkey to remove is required.
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be
+   *     thrown.
+   */
+  void removePasskey(String loginId, String credentialId) throws DescopeException;
+
+  /**
+   * List the registered passkeys (WebAuthn devices) for the user with the given login ID.
+   *
+   * @param loginId The loginID is required.
+   * @return {{@link List} of {@link UserPasskey}} of the user's registered passkeys.
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be
+   *     thrown.
+   */
+  List<UserPasskey> listPasskeys(String loginId) throws DescopeException;
+
+  /**
+   * Update the recovery email for the user with the given login ID.
+   *
+   * @param loginId The loginID is required.
+   * @param email The new recovery email.
+   * @param verified Boolean indicating if the recovery email is verified.
+   * @return The updated {@link UserResponseDetails}.
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be
+   *     thrown.
+   */
+  UserResponseDetails updateRecoveryEmail(String loginId, String email, Boolean verified)
+      throws DescopeException;
+
+  /**
+   * Update the recovery phone for the user with the given login ID.
+   *
+   * @param loginId The loginID is required.
+   * @param phone The new recovery phone.
+   * @param verified Boolean indicating if the recovery phone is verified.
+   * @return The updated {@link UserResponseDetails}.
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be
+   *     thrown.
+   */
+  UserResponseDetails updateRecoveryPhone(String loginId, String phone, Boolean verified)
+      throws DescopeException;
 }

--- a/src/main/java/com/descope/sdk/mgmt/impl/AccessKeyServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/AccessKeyServiceImpl.java
@@ -1,10 +1,14 @@
 package com.descope.sdk.mgmt.impl;
 
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ACCESS_KEY_ACTIVATE_BATCH_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ACCESS_KEY_ACTIVE_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ACCESS_KEY_CREATE_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ACCESS_KEY_DEACTIVATE_BATCH_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ACCESS_KEY_DEACTIVATE_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ACCESS_KEY_DELETE_BATCH_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ACCESS_KEY_DELETE_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ACCESS_KEY_LOAD_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ACCESS_KEY_ROTATE_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ACCESS_KEY_SEARCH_ALL_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ACCESS_KEY_UPDATE_LINK;
 import static com.descope.utils.CollectionUtils.mapOf;
@@ -151,6 +155,47 @@ class AccessKeyServiceImpl extends ManagementsBase implements AccessKeyService {
     Map<String, String> request = mapOf("id", id);
     ApiProxy apiProxy = getApiProxy();
     apiProxy.post(getUri(MANAGEMENT_ACCESS_KEY_DELETE_LINK), request, Void.class);
+  }
+
+  @Override
+  public AccessKeyResponse rotate(String id) throws DescopeException {
+    if (StringUtils.isBlank(id)) {
+      throw ServerCommonException.invalidArgument("id");
+    }
+    Map<String, String> request = mapOf("id", id);
+    ApiProxy apiProxy = getApiProxy();
+    return apiProxy.post(
+        getUri(MANAGEMENT_ACCESS_KEY_ROTATE_LINK), request, AccessKeyResponse.class);
+  }
+
+  @Override
+  public void deactivateBatch(List<String> ids) throws DescopeException {
+    if (ids == null || ids.isEmpty()) {
+      throw ServerCommonException.invalidArgument("ids");
+    }
+    Map<String, List<String>> request = mapOf("ids", ids);
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(MANAGEMENT_ACCESS_KEY_DEACTIVATE_BATCH_LINK), request, Void.class);
+  }
+
+  @Override
+  public void activateBatch(List<String> ids) throws DescopeException {
+    if (ids == null || ids.isEmpty()) {
+      throw ServerCommonException.invalidArgument("ids");
+    }
+    Map<String, List<String>> request = mapOf("ids", ids);
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(MANAGEMENT_ACCESS_KEY_ACTIVATE_BATCH_LINK), request, Void.class);
+  }
+
+  @Override
+  public void deleteBatch(List<String> ids) throws DescopeException {
+    if (ids == null || ids.isEmpty()) {
+      throw ServerCommonException.invalidArgument("ids");
+    }
+    Map<String, List<String>> request = mapOf("ids", ids);
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(MANAGEMENT_ACCESS_KEY_DELETE_BATCH_LINK), request, Void.class);
   }
 
   private AccessKeyRequest createAccessKeyBody(String name, int expireTime, List<String> roleNames,

--- a/src/main/java/com/descope/sdk/mgmt/impl/AuditServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/AuditServiceImpl.java
@@ -2,6 +2,7 @@ package com.descope.sdk.mgmt.impl;
 
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_AUDIT_CREATE_EVENT;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_AUDIT_SEARCH_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_AUDIT_WEBHOOK_CREATE;
 
 import com.descope.enums.AuditType;
 import com.descope.exception.DescopeException;
@@ -10,6 +11,7 @@ import com.descope.model.audit.AuditCreateRequest;
 import com.descope.model.audit.AuditRecord;
 import com.descope.model.audit.AuditSearchRequest;
 import com.descope.model.audit.AuditSearchResponse;
+import com.descope.model.audit.AuditWebhook;
 import com.descope.model.client.Client;
 import com.descope.proxy.ApiProxy;
 import com.descope.sdk.mgmt.AuditService;
@@ -152,5 +154,17 @@ class AuditServiceImpl extends ManagementsBase implements AuditService {
     }
     ApiProxy apiProxy = getApiProxy();
     apiProxy.post(getUri(MANAGEMENT_AUDIT_CREATE_EVENT), request, Void.class);
+  }
+
+  @Override
+  public void createAuditWebhook(AuditWebhook webhook) throws DescopeException {
+    if (webhook == null) {
+      throw ServerCommonException.invalidArgument("AuditWebhook");
+    }
+    if (StringUtils.isBlank(webhook.getName())) {
+      throw ServerCommonException.invalidArgument("AuditWebhook.Name");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(MANAGEMENT_AUDIT_WEBHOOK_CREATE), webhook, Void.class);
   }
 }

--- a/src/main/java/com/descope/sdk/mgmt/impl/FlowServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/FlowServiceImpl.java
@@ -21,6 +21,7 @@ import com.descope.proxy.ApiProxy;
 import com.descope.sdk.mgmt.FlowService;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 class FlowServiceImpl extends ManagementsBase implements FlowService {
@@ -37,6 +38,9 @@ class FlowServiceImpl extends ManagementsBase implements FlowService {
 
   @Override
   public void deleteFlows(List<String> flowIds) throws DescopeException {
+    if (CollectionUtils.isEmpty(flowIds)) {
+      throw ServerCommonException.invalidArgument("flowIds");
+    }
     Map<String, Object> request = mapOf("ids", flowIds);
     ApiProxy apiProxy = getApiProxy();
     apiProxy.post(getUri(FLOW_DELETE_LINK), request, Void.class);

--- a/src/main/java/com/descope/sdk/mgmt/impl/FlowServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/FlowServiceImpl.java
@@ -1,5 +1,6 @@
 package com.descope.sdk.mgmt.impl;
 
+import static com.descope.literals.Routes.ManagementEndPoints.FLOW_DELETE_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.FLOW_EXPORT_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.FLOW_IMPORT_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.FLOW_LIST_LINK;
@@ -32,6 +33,13 @@ class FlowServiceImpl extends ManagementsBase implements FlowService {
   public FlowsResponse listFlows() throws DescopeException {
     ApiProxy apiProxy = getApiProxy();
     return apiProxy.post(getUri(FLOW_LIST_LINK), null, FlowsResponse.class);
+  }
+
+  @Override
+  public void deleteFlows(List<String> flowIds) throws DescopeException {
+    Map<String, Object> request = mapOf("ids", flowIds);
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(FLOW_DELETE_LINK), request, Void.class);
   }
 
   @Override

--- a/src/main/java/com/descope/sdk/mgmt/impl/JwtServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/JwtServiceImpl.java
@@ -1,11 +1,15 @@
 package com.descope.sdk.mgmt.impl;
 
 import static com.descope.literals.Routes.ManagementEndPoints.CLIENT_ASSERTION;
+import static com.descope.literals.Routes.ManagementEndPoints.IMPERSONATE_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.IMPERSONATE_STEPUP_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ANONYMOUS_USER;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_SIGN_IN;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_SIGN_UP;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_SIGN_UP_OR_IN;
+import static com.descope.literals.Routes.ManagementEndPoints.STOP_IMPERSONATION_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.UPDATE_JWT_LINK;
+import static com.descope.utils.CollectionUtils.mapOf;
 
 import com.descope.exception.ClientFunctionalException;
 import com.descope.exception.DescopeException;
@@ -176,5 +180,60 @@ class JwtServiceImpl extends ManagementsBase implements JwtService {
     ApiProxy apiProxy = getApiProxy();
     ClientAssertionResponse response = apiProxy.post(uri, request, ClientAssertionResponse.class);
     return response;
+  }
+
+  @Override
+  public String impersonate(String impersonatorId, String loginId, boolean validateConsent,
+      Map<String, Object> customClaims, String tenantId) throws DescopeException {
+    if (StringUtils.isBlank(loginId)) {
+      throw ServerCommonException.invalidArgument("loginId");
+    }
+    if (StringUtils.isBlank(impersonatorId)) {
+      throw ServerCommonException.invalidArgument("impersonatorId");
+    }
+    Map<String, Object> request = mapOf(
+        "loginId", loginId,
+        "impersonatorId", impersonatorId,
+        "validateConsent", validateConsent,
+        "customClaims", customClaims,
+        "selectedTenant", tenantId);
+    ApiProxy apiProxy = getApiProxy();
+    UpdateJwtResponse jwtResponse = apiProxy.post(getUri(IMPERSONATE_LINK), request, UpdateJwtResponse.class);
+    return jwtResponse.getJwt();
+  }
+
+  @Override
+  public String impersonateStepup(String impersonatorId, String loginId, boolean validateConsent,
+      Map<String, Object> customClaims, String tenantId) throws DescopeException {
+    if (StringUtils.isBlank(loginId)) {
+      throw ServerCommonException.invalidArgument("loginId");
+    }
+    if (StringUtils.isBlank(impersonatorId)) {
+      throw ServerCommonException.invalidArgument("impersonatorId");
+    }
+    Map<String, Object> request = mapOf(
+        "loginId", loginId,
+        "impersonatorId", impersonatorId,
+        "validateConsent", validateConsent,
+        "customClaims", customClaims,
+        "selectedTenant", tenantId);
+    ApiProxy apiProxy = getApiProxy();
+    UpdateJwtResponse jwtResponse = apiProxy.post(getUri(IMPERSONATE_STEPUP_LINK), request, UpdateJwtResponse.class);
+    return jwtResponse.getJwt();
+  }
+
+  @Override
+  public String stopImpersonation(String jwt, Map<String, Object> customClaims, String tenantId)
+      throws DescopeException {
+    if (StringUtils.isBlank(jwt)) {
+      throw ServerCommonException.invalidArgument("jwt");
+    }
+    Map<String, Object> request = mapOf(
+        "jwt", jwt,
+        "customClaims", customClaims,
+        "selectedTenant", tenantId);
+    ApiProxy apiProxy = getApiProxy();
+    UpdateJwtResponse jwtResponse = apiProxy.post(getUri(STOP_IMPERSONATION_LINK), request, UpdateJwtResponse.class);
+    return jwtResponse.getJwt();
   }
 }

--- a/src/main/java/com/descope/sdk/mgmt/impl/PermissionServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/PermissionServiceImpl.java
@@ -5,6 +5,7 @@ import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PERMISS
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PERMISSION_DELETE_BATCH_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PERMISSION_DELETE_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PERMISSION_LOAD_ALL_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PERMISSION_UPDATE_BATCH_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PERMISSION_UPDATE_LINK;
 import static com.descope.utils.CollectionUtils.mapOf;
 
@@ -13,6 +14,7 @@ import com.descope.exception.ServerCommonException;
 import com.descope.model.client.Client;
 import com.descope.model.permission.Permission;
 import com.descope.model.permission.PermissionResponse;
+import com.descope.model.permission.PermissionUpdateRequest;
 import com.descope.proxy.ApiProxy;
 import com.descope.sdk.mgmt.PermissionService;
 import java.util.List;
@@ -72,6 +74,16 @@ class PermissionServiceImpl extends ManagementsBase implements PermissionService
         mapOf("id", id, "newName", newName, "description", description);
     ApiProxy apiProxy = getApiProxy();
     apiProxy.post(getUri(MANAGEMENT_PERMISSION_UPDATE_LINK), request, Void.class);
+  }
+
+  @Override
+  public void updateBatch(List<PermissionUpdateRequest> permissions) throws DescopeException {
+    if (CollectionUtils.isEmpty(permissions)) {
+      throw ServerCommonException.invalidArgument("permissions");
+    }
+    Map<String, Object> request = mapOf("permissions", permissions);
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(MANAGEMENT_PERMISSION_UPDATE_BATCH_LINK), request, Void.class);
   }
 
   @Override

--- a/src/main/java/com/descope/sdk/mgmt/impl/PermissionServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/PermissionServiceImpl.java
@@ -1,6 +1,8 @@
 package com.descope.sdk.mgmt.impl;
 
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PERMISSION_CREATE_BATCH_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PERMISSION_CREATE_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PERMISSION_DELETE_BATCH_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PERMISSION_DELETE_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PERMISSION_LOAD_ALL_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PERMISSION_UPDATE_LINK;
@@ -9,10 +11,13 @@ import static com.descope.utils.CollectionUtils.mapOf;
 import com.descope.exception.DescopeException;
 import com.descope.exception.ServerCommonException;
 import com.descope.model.client.Client;
+import com.descope.model.permission.Permission;
 import com.descope.model.permission.PermissionResponse;
 import com.descope.proxy.ApiProxy;
 import com.descope.sdk.mgmt.PermissionService;
+import java.util.List;
 import java.util.Map;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 class PermissionServiceImpl extends ManagementsBase implements PermissionService {
@@ -32,6 +37,16 @@ class PermissionServiceImpl extends ManagementsBase implements PermissionService
   }
 
   @Override
+  public void createBatch(List<Permission> permissions) throws DescopeException {
+    if (CollectionUtils.isEmpty(permissions)) {
+      throw ServerCommonException.invalidArgument("permissions");
+    }
+    Map<String, Object> request = mapOf("permissions", permissions);
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(MANAGEMENT_PERMISSION_CREATE_BATCH_LINK), request, Void.class);
+  }
+
+  @Override
   public void update(String name, String newName, String description) throws DescopeException {
     if (StringUtils.isBlank(name)) {
       throw ServerCommonException.invalidArgument("Name");
@@ -46,6 +61,20 @@ class PermissionServiceImpl extends ManagementsBase implements PermissionService
   }
 
   @Override
+  public void updateWithId(String id, String newName, String description) throws DescopeException {
+    if (StringUtils.isBlank(id)) {
+      throw ServerCommonException.invalidArgument("id");
+    }
+    if (StringUtils.isBlank(newName)) {
+      throw ServerCommonException.invalidArgument("NewName");
+    }
+    Map<String, String> request =
+        mapOf("id", id, "newName", newName, "description", description);
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(MANAGEMENT_PERMISSION_UPDATE_LINK), request, Void.class);
+  }
+
+  @Override
   public void delete(String name) throws DescopeException {
     if (StringUtils.isBlank(name)) {
       throw ServerCommonException.invalidArgument("Name");
@@ -53,6 +82,26 @@ class PermissionServiceImpl extends ManagementsBase implements PermissionService
     Map<String, String> request = mapOf("name", name);
     ApiProxy apiProxy = getApiProxy();
     apiProxy.post(getUri(MANAGEMENT_PERMISSION_DELETE_LINK), request, Void.class);
+  }
+
+  @Override
+  public void deleteWithId(String id) throws DescopeException {
+    if (StringUtils.isBlank(id)) {
+      throw ServerCommonException.invalidArgument("id");
+    }
+    Map<String, String> request = mapOf("id", id);
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(MANAGEMENT_PERMISSION_DELETE_LINK), request, Void.class);
+  }
+
+  @Override
+  public void deleteBatch(List<String> names, List<String> ids) throws DescopeException {
+    if (CollectionUtils.isEmpty(names) && CollectionUtils.isEmpty(ids)) {
+      throw ServerCommonException.invalidArgument("names");
+    }
+    Map<String, Object> request = mapOf("names", names, "ids", ids);
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(MANAGEMENT_PERMISSION_DELETE_BATCH_LINK), request, Void.class);
   }
 
   @Override

--- a/src/main/java/com/descope/sdk/mgmt/impl/ProjectServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/ProjectServiceImpl.java
@@ -4,6 +4,7 @@ import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_DELETE;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_EXPORT;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_IMPORT;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_LIST;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_UPDATE_NAME;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_UPDATE_TAGS;
 import static com.descope.utils.CollectionUtils.mapOf;
@@ -13,6 +14,8 @@ import com.descope.exception.DescopeException;
 import com.descope.model.client.Client;
 import com.descope.model.project.ExportProjectResponse;
 import com.descope.model.project.NewProjectResponse;
+import com.descope.model.project.Project;
+import com.descope.model.project.ProjectsResponse;
 import com.descope.proxy.ApiProxy;
 import com.descope.sdk.mgmt.ProjectService;
 import java.util.HashMap;
@@ -65,5 +68,12 @@ class ProjectServiceImpl extends ManagementsBase implements ProjectService {
   public void deleteProject() throws DescopeException {
     ApiProxy apiProxy = getApiProxy();
     apiProxy.post(getUri(MANAGEMENT_PROJECT_DELETE), new HashMap<>(), Void.class);
+  }
+
+  @Override
+  public List<Project> listProjects() throws DescopeException {
+    ApiProxy apiProxy = getApiProxy();
+    ProjectsResponse resp = apiProxy.post(getUri(MANAGEMENT_PROJECT_LIST), null, ProjectsResponse.class);
+    return resp == null ? null : resp.getProjects();
   }
 }

--- a/src/main/java/com/descope/sdk/mgmt/impl/ProjectServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/ProjectServiceImpl.java
@@ -1,9 +1,11 @@
 package com.descope.sdk.mgmt.impl;
 
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_CLONE;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_DELETE;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_EXPORT;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_IMPORT;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_UPDATE_NAME;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_PROJECT_UPDATE_TAGS;
 import static com.descope.utils.CollectionUtils.mapOf;
 
 import com.descope.enums.ProjectTag;
@@ -13,6 +15,8 @@ import com.descope.model.project.ExportProjectResponse;
 import com.descope.model.project.NewProjectResponse;
 import com.descope.proxy.ApiProxy;
 import com.descope.sdk.mgmt.ProjectService;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 class ProjectServiceImpl extends ManagementsBase implements ProjectService {
@@ -48,5 +52,18 @@ class ProjectServiceImpl extends ManagementsBase implements ProjectService {
     ApiProxy apiProxy = getApiProxy();
     Map<String, Object> request = mapOf("files", files);
     apiProxy.post(getUri(MANAGEMENT_PROJECT_IMPORT), request, Void.class);
+  }
+
+  @Override
+  public void updateTags(List<String> tags) throws DescopeException {
+    ApiProxy apiProxy = getApiProxy();
+    Map<String, Object> request = mapOf("tags", tags);
+    apiProxy.post(getUri(MANAGEMENT_PROJECT_UPDATE_TAGS), request, Void.class);
+  }
+
+  @Override
+  public void deleteProject() throws DescopeException {
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(MANAGEMENT_PROJECT_DELETE), new HashMap<>(), Void.class);
   }
 }

--- a/src/main/java/com/descope/sdk/mgmt/impl/RolesServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/RolesServiceImpl.java
@@ -80,6 +80,16 @@ class RolesServiceImpl extends ManagementsBase implements RolesService {
   }
 
   @Override
+  public void deleteWithId(String id, String tenantId) throws DescopeException {
+    if (StringUtils.isBlank(id)) {
+      throw ServerCommonException.invalidArgument("id");
+    }
+    Map<String, String> request = mapOf("id", id, "tenantId", tenantId);
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(MANAGEMENT_ROLES_DELETE_LINK), request, Void.class);
+  }
+
+  @Override
   public RoleResponse loadAll() throws DescopeException {
     ApiProxy apiProxy = getApiProxy();
     return apiProxy.get(getUri(MANAGEMENT_ROLES_LOAD_ALL_LINK), RoleResponse.class);

--- a/src/main/java/com/descope/sdk/mgmt/impl/RolesServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/RolesServiceImpl.java
@@ -1,21 +1,27 @@
 package com.descope.sdk.mgmt.impl;
 
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ROLES_CREATE_BATCH_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ROLES_CREATE_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ROLES_DELETE_BATCH_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ROLES_DELETE_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ROLES_LOAD_ALL_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ROLES_SEARCH_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ROLES_UPDATE_BATCH_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_ROLES_UPDATE_LINK;
 import static com.descope.utils.CollectionUtils.mapOf;
 
 import com.descope.exception.DescopeException;
 import com.descope.exception.ServerCommonException;
 import com.descope.model.client.Client;
+import com.descope.model.roles.Role;
 import com.descope.model.roles.RoleResponse;
 import com.descope.model.roles.RoleSearchOptions;
+import com.descope.model.roles.RoleUpdateRequest;
 import com.descope.proxy.ApiProxy;
 import com.descope.sdk.mgmt.RolesService;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 class RolesServiceImpl extends ManagementsBase implements RolesService {
@@ -44,6 +50,16 @@ class RolesServiceImpl extends ManagementsBase implements RolesService {
   }
 
   @Override
+  public RoleResponse createBatch(List<Role> roles) throws DescopeException {
+    if (CollectionUtils.isEmpty(roles)) {
+      throw ServerCommonException.invalidArgument("roles");
+    }
+    Map<String, Object> request = mapOf("roles", roles);
+    ApiProxy apiProxy = getApiProxy();
+    return apiProxy.post(getUri(MANAGEMENT_ROLES_CREATE_BATCH_LINK), request, RoleResponse.class);
+  }
+
+  @Override
   public void update(String name, String newName, String description, List<String> permissionNames)
       throws DescopeException {
     this.update(name, "", newName, description, permissionNames);
@@ -62,6 +78,16 @@ class RolesServiceImpl extends ManagementsBase implements RolesService {
         permissionNames, "tenantId", tenantId);
     ApiProxy apiProxy = getApiProxy();
     apiProxy.post(getUri(MANAGEMENT_ROLES_UPDATE_LINK), request, Void.class);
+  }
+
+  @Override
+  public RoleResponse updateBatch(List<RoleUpdateRequest> roles) throws DescopeException {
+    if (CollectionUtils.isEmpty(roles)) {
+      throw ServerCommonException.invalidArgument("roles");
+    }
+    Map<String, Object> request = mapOf("roles", roles);
+    ApiProxy apiProxy = getApiProxy();
+    return apiProxy.post(getUri(MANAGEMENT_ROLES_UPDATE_BATCH_LINK), request, RoleResponse.class);
   }
 
   @Override
@@ -87,6 +113,16 @@ class RolesServiceImpl extends ManagementsBase implements RolesService {
     Map<String, String> request = mapOf("id", id, "tenantId", tenantId);
     ApiProxy apiProxy = getApiProxy();
     apiProxy.post(getUri(MANAGEMENT_ROLES_DELETE_LINK), request, Void.class);
+  }
+
+  @Override
+  public void deleteBatch(List<String> roleNames, String tenantId, List<String> roleIds) throws DescopeException {
+    if (CollectionUtils.isEmpty(roleNames) && CollectionUtils.isEmpty(roleIds)) {
+      throw ServerCommonException.invalidArgument("roleNames");
+    }
+    Map<String, Object> request = mapOf("roleNames", roleNames, "tenantId", tenantId, "roleIds", roleIds);
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(MANAGEMENT_ROLES_DELETE_BATCH_LINK), request, Void.class);
   }
 
   @Override

--- a/src/main/java/com/descope/sdk/mgmt/impl/SsoApplicationServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/SsoApplicationServiceImpl.java
@@ -5,8 +5,10 @@ import static com.descope.literals.Routes.ManagementEndPoints.SSO_APPLICATION_LO
 import static com.descope.literals.Routes.ManagementEndPoints.SSO_APPLICATION_LOAD_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.SSO_APPLICATION_OIDC_CREATE_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.SSO_APPLICATION_OIDC_UPDATE_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.SSO_APPLICATION_ROTATE_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.SSO_APPLICATION_SAML_CREATE_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.SSO_APPLICATION_SAML_UPDATE_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.SSO_APPLICATION_SECRET_LINK;
 import static com.descope.utils.CollectionUtils.mapOf;
 
 import com.descope.exception.DescopeException;
@@ -16,6 +18,7 @@ import com.descope.model.mgmt.IDResponse;
 import com.descope.model.ssoapp.OIDCApplicationRequest;
 import com.descope.model.ssoapp.SAMLApplicationRequest;
 import com.descope.model.ssoapp.SSOApplication;
+import com.descope.model.ssoapp.SSOApplicationSecretResponse;
 import com.descope.model.ssoapp.SSOApplications;
 import com.descope.proxy.ApiProxy;
 import com.descope.sdk.mgmt.SsoApplicationService;
@@ -106,5 +109,27 @@ class SsoApplicationServiceImpl extends ManagementsBase implements SsoApplicatio
     ApiProxy apiProxy = getApiProxy();
     SSOApplications apps = apiProxy.get(getUri(SSO_APPLICATION_LOAD_ALL_LINK), SSOApplications.class);
     return apps.getApps();
+  }
+
+  @Override
+  public String getApplicationSecret(String id) throws DescopeException {
+    if (StringUtils.isBlank(id)) {
+      throw ServerCommonException.invalidArgument("id");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    SSOApplicationSecretResponse res = apiProxy.get(getQueryParamUri(SSO_APPLICATION_SECRET_LINK, mapOf("id", id)),
+        SSOApplicationSecretResponse.class);
+    return res.getCleartext();
+  }
+
+  @Override
+  public String rotateApplicationSecret(String id) throws DescopeException {
+    if (StringUtils.isBlank(id)) {
+      throw ServerCommonException.invalidArgument("id");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    SSOApplicationSecretResponse res = apiProxy.post(getUri(SSO_APPLICATION_ROTATE_LINK), mapOf("id", id),
+        SSOApplicationSecretResponse.class);
+    return res.getCleartext();
   }
 }

--- a/src/main/java/com/descope/sdk/mgmt/impl/SsoServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/SsoServiceImpl.java
@@ -10,6 +10,8 @@ import static com.descope.literals.Routes.ManagementEndPoints.SSO_DELETE_SETTING
 import static com.descope.literals.Routes.ManagementEndPoints.SSO_GET_ALL_SETTINGS_V2_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.SSO_GET_SETTINGS_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.SSO_GET_SETTINGS_V2_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.SSO_RECALCULATE_MAPPINGS_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.SSO_REDIRECT_URL_LINK;
 import static com.descope.utils.CollectionUtils.mapOf;
 
 import com.descope.exception.DescopeException;
@@ -128,6 +130,34 @@ class SsoServiceImpl extends ManagementsBase implements SsoService {
     Map<String, String> request = mapOf("tenantId", tenantId);
     ApiProxy apiProxy = getApiProxy();
     apiProxy.delete(getQueryParamUri(SSO_DELETE_SETTINGS_LINK, request), null, Void.class);
+  }
+
+  @Override
+  public void configureSSORedirectURL(String tenantId, String samlRedirectUrl, String oauthRedirectUrl, String ssoId)
+      throws DescopeException {
+    if (StringUtils.isBlank(tenantId)) {
+      throw ServerCommonException.invalidArgument("TenantId");
+    }
+    Map<String, Object> req = mapOf("tenantId", tenantId, "samlRedirectUrl", samlRedirectUrl,
+        "oauthRedirectUrl", oauthRedirectUrl);
+    if (StringUtils.isNotBlank(ssoId)) {
+      req.put("ssoId", ssoId);
+    }
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(SSO_REDIRECT_URL_LINK), req, Void.class);
+  }
+
+  @Override
+  public void recalculateSSOMappings(String tenantId, String ssoId) throws DescopeException {
+    if (StringUtils.isBlank(tenantId)) {
+      throw ServerCommonException.invalidArgument("TenantId");
+    }
+    Map<String, Object> req = mapOf("tenantId", tenantId);
+    if (StringUtils.isNotBlank(ssoId)) {
+      req.put("ssoId", ssoId);
+    }
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(SSO_RECALCULATE_MAPPINGS_LINK), req, Void.class);
   }
 
   // DEPRECATED METHODS

--- a/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/TenantServiceImpl.java
@@ -8,6 +8,7 @@ import static com.descope.literals.Routes.ManagementEndPoints.LOAD_ALL_TENANTS_L
 import static com.descope.literals.Routes.ManagementEndPoints.LOAD_TENANT_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.REVOKE_SSO_CONFIGURATION_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.TENANT_SEARCH_ALL_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.TENANT_UPDATE_DEFAULT_ROLES_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.UPDATE_TENANT_LINK;
 import static com.descope.utils.CollectionUtils.addIfNotNull;
 import static com.descope.utils.CollectionUtils.mapOf;
@@ -228,6 +229,19 @@ class TenantServiceImpl extends ManagementsBase implements TenantService {
     URI revokeSSOConfigurationLinkUri = revokeSSOConfigurationLinkUri();
     ApiProxy apiProxy = getApiProxy();
     apiProxy.post(revokeSSOConfigurationLinkUri, req, Void.class);
+  }
+
+  @Override
+  public void updateDefaultRoles(String tenantId, List<String> defaultRoles) throws DescopeException {
+    if (StringUtils.isBlank(tenantId)) {
+      throw ServerCommonException.invalidArgument("tenantId");
+    }
+
+    Map<String, Object> req = mapOf("id", tenantId);
+    req.put("defaultRoles", defaultRoles);
+
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(TENANT_UPDATE_DEFAULT_ROLES_LINK), req, Void.class);
   }
 
   private URI composeCreateTenantUri() {

--- a/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
@@ -20,11 +20,16 @@ import static com.descope.literals.Routes.ManagementEndPoints.USER_ADD_ROLES_LIN
 import static com.descope.literals.Routes.ManagementEndPoints.USER_ADD_SSO_APPS_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_ADD_TENANT_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_CREATE_EMBEDDED_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.USER_DELETE_BATCH_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_EXPIRE_PASSWORD_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_HISTORY_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.USER_LIST_PASSKEYS_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.USER_REMOVE_ALL_PASSKEYS_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.USER_REMOVE_PASSKEY_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_REMOVE_ROLES_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_REMOVE_SSO_APPS_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_REMOVE_TENANT_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.USER_REMOVE_TOTP_SEED_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SEARCH_ALL_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_ACTIVE_PASSWORD_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_PASSWORD_LINK;
@@ -34,6 +39,8 @@ import static com.descope.literals.Routes.ManagementEndPoints.USER_SET_TEMPORARY
 import static com.descope.literals.Routes.ManagementEndPoints.USER_SIGNUP_EMBEDDED_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_UPDATE_EMAIL_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_UPDATE_PHONE_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.USER_UPDATE_RECOVERY_EMAIL_LINK;
+import static com.descope.literals.Routes.ManagementEndPoints.USER_UPDATE_RECOVERY_PHONE_LINK;
 import static com.descope.literals.Routes.ManagementEndPoints.USER_UPDATE_STATUS_LINK;
 import static com.descope.utils.CollectionUtils.addIfNotBlank;
 import static com.descope.utils.CollectionUtils.addIfNotNull;
@@ -62,6 +69,8 @@ import com.descope.model.user.response.MagicLinkTestUserResponse;
 import com.descope.model.user.response.OTPTestUserResponse;
 import com.descope.model.user.response.ProviderTokenResponse;
 import com.descope.model.user.response.UserHistoryResponse;
+import com.descope.model.user.response.UserPasskey;
+import com.descope.model.user.response.UserPasskeysResponse;
 import com.descope.model.user.response.UserResponseDetails;
 import com.descope.model.user.response.UsersBatchResponse;
 import com.descope.proxy.ApiProxy;
@@ -209,6 +218,80 @@ class UserServiceImpl extends ManagementsBase implements UserService {
     URI deleteUserUri = composeDeleteUserUri();
     ApiProxy apiProxy = getApiProxy();
     apiProxy.post(deleteUserUri, mapOf("userId", userId), Void.class);
+  }
+
+  @Override
+  public void deleteBatch(List<String> userIds) throws DescopeException {
+    if (CollectionUtils.isEmpty(userIds)) {
+      throw ServerCommonException.invalidArgument("User IDs");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(USER_DELETE_BATCH_LINK), mapOf("userIds", userIds), Void.class);
+  }
+
+  @Override
+  public void removeTOTPSeed(String loginId) throws DescopeException {
+    if (StringUtils.isBlank(loginId)) {
+      throw ServerCommonException.invalidArgument("Login ID");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(USER_REMOVE_TOTP_SEED_LINK), mapOf("loginId", loginId), Void.class);
+  }
+
+  @Override
+  public void removeAllPasskeys(String loginId) throws DescopeException {
+    if (StringUtils.isBlank(loginId)) {
+      throw ServerCommonException.invalidArgument("Login ID");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(USER_REMOVE_ALL_PASSKEYS_LINK), mapOf("loginId", loginId), Void.class);
+  }
+
+  @Override
+  public void removePasskey(String loginId, String credentialId) throws DescopeException {
+    if (StringUtils.isBlank(loginId)) {
+      throw ServerCommonException.invalidArgument("Login ID");
+    }
+    if (StringUtils.isBlank(credentialId)) {
+      throw ServerCommonException.invalidArgument("Credential ID");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    apiProxy.post(getUri(USER_REMOVE_PASSKEY_LINK),
+        mapOf("loginId", loginId, "credentialId", credentialId), Void.class);
+  }
+
+  @Override
+  public List<UserPasskey> listPasskeys(String loginId) throws DescopeException {
+    if (StringUtils.isBlank(loginId)) {
+      throw ServerCommonException.invalidArgument("Login ID");
+    }
+    ApiProxy apiProxy = getApiProxy();
+    UserPasskeysResponse response =
+        apiProxy.post(getUri(USER_LIST_PASSKEYS_LINK), mapOf("loginId", loginId),
+            UserPasskeysResponse.class);
+    return response == null ? null : response.getPasskeys();
+  }
+
+  @Override
+  public UserResponseDetails updateRecoveryEmail(String loginId, String email, Boolean verified)
+      throws DescopeException {
+    if (StringUtils.isBlank(loginId)) {
+      throw ServerCommonException.invalidArgument("Login ID");
+    }
+    Map<String, Object> request = mapOf("loginId", loginId, "recoveryEmail", email, "verified", verified);
+    ApiProxy apiProxy = getApiProxy();
+    return apiProxy.post(getUri(USER_UPDATE_RECOVERY_EMAIL_LINK), request, UserResponseDetails.class);
+  }
+
+  @Override
+  public UserResponseDetails updateRecoveryPhone(String loginId, String phone, Boolean verified)
+      throws DescopeException {
+    if (StringUtils.isBlank(loginId)) {
+      throw ServerCommonException.invalidArgument("Login ID");
+    }
+    Map<String, Object> request = mapOf("loginId", loginId, "recoveryPhone", phone, "verified", verified);
+    ApiProxy apiProxy = getApiProxy();
+    return apiProxy.post(getUri(USER_UPDATE_RECOVERY_PHONE_LINK), request, UserResponseDetails.class);
   }
 
   @Override

--- a/src/test/java/com/descope/sdk/mgmt/impl/PermissionServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/PermissionServiceImplTest.java
@@ -17,6 +17,7 @@ import com.descope.exception.ServerCommonException;
 import com.descope.model.client.Client;
 import com.descope.model.permission.Permission;
 import com.descope.model.permission.PermissionResponse;
+import com.descope.model.permission.PermissionUpdateRequest;
 import com.descope.proxy.ApiProxy;
 import com.descope.proxy.impl.ApiProxyBuilder;
 import com.descope.sdk.TestUtils;
@@ -125,6 +126,27 @@ class PermissionServiceImplTest {
       Assertions.assertThat(response.getPermissions().get(0).getName()).isEqualTo("someName");
       Assertions.assertThat(response.getPermissions().get(0).getDescription())
           .isEqualTo("someDesc");
+    }
+  }
+
+  @Test
+  void testUpdateBatchForEmpty() {
+    ServerCommonException thrown =
+        assertThrows(ServerCommonException.class, () -> permissionService.updateBatch(null));
+    assertNotNull(thrown);
+    assertEquals("The permissions argument is invalid", thrown.getMessage());
+  }
+
+  @Test
+  void testUpdateBatchForSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(Void.class).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(
+        () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      permissionService.updateBatch(Arrays.asList(
+          PermissionUpdateRequest.builder().id("p1").newName("newName").build()));
+      verify(apiProxy, times(1)).post(any(), any(), any());
     }
   }
 

--- a/src/test/java/com/descope/sdk/mgmt/impl/ProjectServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/ProjectServiceImplTest.java
@@ -13,10 +13,14 @@ import com.descope.model.client.Client;
 import com.descope.model.mgmt.ManagementServices;
 import com.descope.model.project.ExportProjectResponse;
 import com.descope.model.project.NewProjectResponse;
+import com.descope.model.project.Project;
+import com.descope.model.project.ProjectsResponse;
 import com.descope.proxy.ApiProxy;
 import com.descope.proxy.impl.ApiProxyBuilder;
 import com.descope.sdk.TestUtils;
 import com.descope.sdk.mgmt.ProjectService;
+import java.util.Arrays;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,6 +84,22 @@ public class ProjectServiceImplTest {
         () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
       projectService.importProject(mockExportResponse.getFiles());
       verify(apiProxy, times(1)).post(any(), any(), any());
+    }
+  }
+
+  @Test
+  void testListProjectsForSuccess() {
+    ProjectsResponse mockResponse = ProjectsResponse.builder()
+        .projects(Arrays.asList(Project.builder().id("p1").name("name1").environment("production").build()))
+        .build();
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(mockResponse).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(
+          () -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      List<Project> projects = projectService.listProjects();
+      Assertions.assertThat(projects).hasSize(1);
+      Assertions.assertThat(projects.get(0).getId()).isEqualTo("p1");
     }
   }
 }

--- a/src/test/java/com/descope/sdk/mgmt/impl/RolesServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/RolesServiceImplTest.java
@@ -20,6 +20,7 @@ import com.descope.model.mgmt.ManagementServices;
 import com.descope.model.roles.Role;
 import com.descope.model.roles.RoleResponse;
 import com.descope.model.roles.RoleSearchOptions;
+import com.descope.model.roles.RoleUpdateRequest;
 import com.descope.proxy.ApiProxy;
 import com.descope.proxy.impl.ApiProxyBuilder;
 import com.descope.sdk.TestUtils;
@@ -130,6 +131,66 @@ class RolesServiceImplTest {
       Assertions.assertThat(response.getRoles().get(0).getPermissionNames().size()).isEqualTo(2);
       Assertions.assertThat(response.getRoles().get(0).getPermissionNames().get(0)).isEqualTo("permission1");
       Assertions.assertThat(response.getRoles().get(0).getPermissionNames().get(1)).isEqualTo("permission2");
+    }
+  }
+
+  @Test
+  void testCreateBatchForEmpty() {
+    ServerCommonException thrown =
+        assertThrows(ServerCommonException.class, () -> rolesService.createBatch(null));
+    assertNotNull(thrown);
+    assertEquals("The roles argument is invalid", thrown.getMessage());
+  }
+
+  @Test
+  void testCreateBatchForSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(mockRoleResponse).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      RoleResponse response = rolesService.createBatch(mockRole);
+      assertThat(response.getRoles()).hasSize(1);
+      verify(apiProxy, times(1)).post(any(), any(), any());
+    }
+  }
+
+  @Test
+  void testUpdateBatchForEmpty() {
+    ServerCommonException thrown =
+        assertThrows(ServerCommonException.class, () -> rolesService.updateBatch(null));
+    assertNotNull(thrown);
+    assertEquals("The roles argument is invalid", thrown.getMessage());
+  }
+
+  @Test
+  void testUpdateBatchForSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(mockRoleResponse).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      RoleResponse response = rolesService.updateBatch(Arrays.asList(
+          RoleUpdateRequest.builder().name("someName").newName("newName").build()));
+      assertThat(response.getRoles()).hasSize(1);
+      verify(apiProxy, times(1)).post(any(), any(), any());
+    }
+  }
+
+  @Test
+  void testDeleteBatchForEmpty() {
+    ServerCommonException thrown = assertThrows(ServerCommonException.class,
+        () -> rolesService.deleteBatch(null, "", null));
+    assertNotNull(thrown);
+    assertEquals("The roleNames argument is invalid", thrown.getMessage());
+  }
+
+  @Test
+  void testDeleteBatchForSuccess() {
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(Void.class).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      rolesService.deleteBatch(Arrays.asList("someName"), "", null);
+      verify(apiProxy, times(1)).post(any(), any(), any());
     }
   }
 


### PR DESCRIPTION
Fixes descope/etc#16608

[View workflow run](https://github.com/descope/shuni/actions/runs/28677923728)

Done. Committed to branch `shuni/task-20260703183923` (no push/PR per constraints).

## What I did

Closed method-level parity gaps between the Java and Go management SDKs, following the existing Java patterns exactly (validate → build payload → `apiProxy.post(getUri(ROUTE), body, T.class)`). Route constants, README examples, and Javadoc added for every method.

**Methods added (23 across 11 services):**
- **AccessKey**: `rotate`, `activateBatch`, `deactivateBatch`, `deleteBatch`
- **Tenant**: `updateDefaultRoles`
- **JWT**: `impersonate`, `impersonateStepup`, `stopImpersonation`
- **Permission**: `createBatch`, `updateWithId`, `deleteWithId`, `deleteBatch`
- **Role**: `deleteWithId`
- **SSO**: `configureSSORedirectURL`, `recalculateSSOMappings`
- **SSOApplication**: `getApplicationSecret`, `rotateApplicationSecret`
- **Audit**: `createAuditWebhook`
- **Flow**: `deleteFlows`
- **Project**: `updateTags`, `deleteProject`
- **User**: `deleteBatch`, `updateRecoveryEmail`, `updateRecoveryPhone`, `listPasskeys`, `removePasskey`, `removeAllPasskeys`, `removeTOTPSeed`

**New models**: `AuditWebhook` (+ auth/filter tree), `SSOApplicationSecretResponse`, `UserPasskey`, `UserPasskeysResponse`.

**Quality gate (3/3):** checkstyle 0 violations · `mvn compile`/`test-compile` BUILD SUCCESS · mgmt unit tests pass (the only test errors are pre-existing `testFunctionalFullCycle` integration tests needing live backend credentials — environmental, not a regression).

Body field names and endpoints were each verified against `/tmp/go-sdk` source, not guessed (e.g. Go uses `"id"` not `"tenantId"` for `updateDefaultRoles`; recovery uses `recoveryEmail`/`recoveryPhone`/`verified`).

Scope note for faithful reporting: this pass covered the gaps within services that already exist in the Java SDK. The Go SDK also exposes entire services the Java SDK doesn't have yet (Engine, List, ManagementKey, Descoper, Analytics, JWTTemplate, ScopeClaimMapping) and a few heavier method groups (project snapshot export/import/validate, FGA dryRun/mappable-resources, user import/patchBatch/trusted-devices, SSO WSFed apps) — each needs its own new model set + service wiring, which is a separate large body of work beyond this session's build-verified batch.

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*