### PR TITLE
feat(fga): add dryRunSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1497,6 +1497,18 @@ try {
     // Handle the error
 }
 
+// Preview what saving a schema would delete, without saving it
+try {
+    FGASchemaDryRunResponse dryRun = fs.dryRunSchema(new FGASchema(dsl));
+    FGASchemaDryDeletes deletes = dryRun.getDeletesPreview();
+    if (deletes != null && deletes.isHasDeletes()) {
+        System.out.println("Would delete relations: " + deletes.getRelations());
+        System.out.println("Would delete types: " + deletes.getTypes());
+    }
+} catch (DescopeException de) {
+    // Handle the error
+}
+
 // Load the current authorization schema
 try {
     FGASchema schema = fs.loadSchema();

--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -233,6 +233,7 @@ public class Routes {
     public static final String MANAGEMENT_FGA_CHECK = "/v1/mgmt/fga/check";
     public static final String MANAGEMENT_FGA_RESOURCES_LOAD = "/v1/mgmt/fga/resources/load";
     public static final String MANAGEMENT_FGA_RESOURCES_SAVE = "/v1/mgmt/fga/resources/save";
+    public static final String MANAGEMENT_FGA_SCHEMA_DRY_RUN = "/v1/mgmt/fga/schema/dryrun";
 
     // Password settings
     public static final String MANAGEMENT_PASSWORD_SETTINGS = "/v1/mgmt/password/settings";

--- a/src/main/java/com/descope/model/fga/FGASchemaDryDeletes.java
+++ b/src/main/java/com/descope/model/fga/FGASchemaDryDeletes.java
@@ -1,0 +1,17 @@
+package com.descope.model.fga;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FGASchemaDryDeletes {
+  private boolean hasDeletes;
+  private List<String> relations;
+  private List<String> types;
+}

--- a/src/main/java/com/descope/model/fga/FGASchemaDryRunResponse.java
+++ b/src/main/java/com/descope/model/fga/FGASchemaDryRunResponse.java
@@ -1,0 +1,14 @@
+package com.descope.model.fga;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FGASchemaDryRunResponse {
+  private FGASchemaDryDeletes deletesPreview;
+}

--- a/src/main/java/com/descope/sdk/mgmt/FGAService.java
+++ b/src/main/java/com/descope/sdk/mgmt/FGAService.java
@@ -6,6 +6,7 @@ import com.descope.model.fga.FGARelation;
 import com.descope.model.fga.FGAResourceDetails;
 import com.descope.model.fga.FGAResourceIdentifier;
 import com.descope.model.fga.FGASchema;
+import com.descope.model.fga.FGASchemaDryRunResponse;
 import java.util.List;
 
 /**
@@ -22,6 +23,16 @@ public interface FGAService {
    * @throws DescopeException if the operation fails
    */
   void saveSchema(FGASchema schema) throws DescopeException;
+
+  /**
+   * Validates an FGA schema without saving it, and reports what saving it would delete
+   * from the current schema.
+   *
+   * @param schema the FGA schema containing the DSL definition
+   * @return a preview of the relations and types that would be deleted
+   * @throws DescopeException if the operation fails
+   */
+  FGASchemaDryRunResponse dryRunSchema(FGASchema schema) throws DescopeException;
 
   /**
    * Loads the current FGA schema for the project.

--- a/src/main/java/com/descope/sdk/mgmt/impl/FGAServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/FGAServiceImpl.java
@@ -7,6 +7,7 @@ import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FGA_LOA
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FGA_RESOURCES_LOAD;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FGA_RESOURCES_SAVE;
 import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FGA_SAVE_SCHEMA;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_FGA_SCHEMA_DRY_RUN;
 
 import com.descope.exception.DescopeException;
 import com.descope.exception.ServerCommonException;
@@ -16,6 +17,7 @@ import com.descope.model.fga.FGARelation;
 import com.descope.model.fga.FGAResourceDetails;
 import com.descope.model.fga.FGAResourceIdentifier;
 import com.descope.model.fga.FGASchema;
+import com.descope.model.fga.FGASchemaDryRunResponse;
 import com.descope.proxy.ApiProxy;
 import com.descope.sdk.mgmt.FGAService;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -42,6 +44,19 @@ class FGAServiceImpl extends ManagementsBase implements FGAService {
 
     ApiProxy apiProxy = getApiProxy();
     apiProxy.post(getUri(MANAGEMENT_FGA_SAVE_SCHEMA), requestBody, Void.class);
+  }
+
+  @Override
+  public FGASchemaDryRunResponse dryRunSchema(FGASchema schema) throws DescopeException {
+    if (schema == null || StringUtils.isBlank(schema.getDsl())) {
+      throw ServerCommonException.invalidArgument("FGA schema DSL");
+    }
+
+    Map<String, Object> requestBody = new HashMap<>();
+    requestBody.put("dsl", schema.getDsl());
+
+    ApiProxy apiProxy = getApiProxy();
+    return apiProxy.post(getUri(MANAGEMENT_FGA_SCHEMA_DRY_RUN), requestBody, FGASchemaDryRunResponse.class);
   }
 
   @Override

--- a/src/test/java/com/descope/sdk/mgmt/impl/FGAServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/FGAServiceImplTest.java
@@ -3,6 +3,7 @@ package com.descope.sdk.mgmt.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -17,6 +18,8 @@ import com.descope.model.fga.FGARelation;
 import com.descope.model.fga.FGAResourceDetails;
 import com.descope.model.fga.FGAResourceIdentifier;
 import com.descope.model.fga.FGASchema;
+import com.descope.model.fga.FGASchemaDryDeletes;
+import com.descope.model.fga.FGASchemaDryRunResponse;
 import com.descope.model.mgmt.ManagementServices;
 import com.descope.proxy.ApiProxy;
 import com.descope.proxy.impl.ApiProxyBuilder;
@@ -83,6 +86,35 @@ class FGAServiceImplTest {
   void testSaveSchema_EmptyDSL() {
     FGASchema schema = new FGASchema("");
     assertThrows(ServerCommonException.class, () -> fgaService.saveSchema(schema));
+  }
+
+  @Test
+  void testDryRunSchema_Success() throws Exception {
+    FGASchema schema = new FGASchema("model AuthZ 1.0\ntype user");
+    FGASchemaDryRunResponse response = new FGASchemaDryRunResponse(
+        new FGASchemaDryDeletes(true, Arrays.asList("doc#viewer"), Arrays.asList("doc")));
+
+    try (MockedStatic<ApiProxyBuilder> mockedStatic = Mockito.mockStatic(ApiProxyBuilder.class)) {
+      mockedStatic.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      when(apiProxy.post(any(), any(), eq(FGASchemaDryRunResponse.class))).thenReturn(response);
+
+      FGASchemaDryRunResponse result = fgaService.dryRunSchema(schema);
+
+      assertNotNull(result);
+      assertTrue(result.getDeletesPreview().isHasDeletes());
+      assertEquals(Arrays.asList("doc#viewer"), result.getDeletesPreview().getRelations());
+      assertEquals(Arrays.asList("doc"), result.getDeletesPreview().getTypes());
+    }
+  }
+
+  @Test
+  void testDryRunSchema_NullSchema() {
+    assertThrows(ServerCommonException.class, () -> fgaService.dryRunSchema(null));
+  }
+
+  @Test
+  void testDryRunSchema_EmptyDSL() {
+    assertThrows(ServerCommonException.class, () -> fgaService.dryRunSchema(new FGASchema("")));
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/17574

## In a Nutshell
- Add `FGAService.dryRunSchema`
- New `FGASchemaDryRunResponse` / `FGASchemaDryDeletes` models
- Docs + unit tests

## Description
Ports `DryRunSchema` from the Go SDK: posts the DSL to `/v1/mgmt/fga/schema/dryrun` and returns a preview of the relations and types that saving the schema would delete, without saving it. Validation matches `saveSchema` (null schema / blank DSL rejected before any HTTP call), and the call stays on the API host — the Go SDK does not route dry-run through the FGA cache.

First of four stacked PRs bringing the Java SDK's FGA surface to parity with `go-sdk@main`. The next three add ABAC context support, FGA cache routing, and live coverage.

## Must
- [x] Tests
- [x] Documentation (if applicable)