### PR TITLE
test(fga): live coverage for dry-run, ABAC and cache routing

### DIFF
--- a/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
@@ -1,5 +1,6 @@
 package com.descope.sdk.mgmt.impl;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -27,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junitpioneer.jupiter.RetryingTest;
 
@@ -93,16 +93,8 @@ class FGALiveTest {
     authzService = services.getAuthzService();
   }
 
-  // Cleaning up once, not per test: every test saves the schema it needs, and the project is
-  // shared with the other live tests, so deleting the schema between tests only adds churn.
-  @AfterAll
-  static void deleteSchema() {
-    try {
-      ManagementServiceBuilder.buildServices(TestUtils.getClient()).getAuthzService().deleteSchema();
-    } catch (Exception ignored) {
-      // The schema may already be gone, nothing to clean up.
-    }
-  }
+  // No schema cleanup on purpose: every test here saves the schema it needs, and the project is
+  // shared with the other live tests, some of which read the schema without a null guard.
 
   @RetryingTest(value = 3, suspendForMs = 30000,
       onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
@@ -272,7 +264,7 @@ class FGALiveTest {
     assertNotNull(badFga.dryRunSchema(new FGASchema(SIMPLE_SCHEMA)));
     badFga.saveResourcesDetails(details);
     assertNotNull(badFga.loadResourcesDetails(Arrays.asList(new FGAResourceIdentifier("doc1", "document"))));
-    assertNotNull(badAuthz.resourceRelations("doc1"));
+    assertDoesNotThrow(() -> badAuthz.resourceRelations("doc1"));
   }
 
   @RetryingTest(value = 3, suspendForMs = 30000,

--- a/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.descope.exception.RateLimitExceededException;
+import com.descope.exception.ServerCommonException;
 import com.descope.model.client.Client;
 import com.descope.model.fga.FGACheckResult;
 import com.descope.model.fga.FGARelation;
@@ -32,7 +33,8 @@ import org.junitpioneer.jupiter.RetryingTest;
 
 /**
  * Live coverage for the FGA surface, mirroring integrationtests/tests/fga_test.go.
- * Requires DESCOPE_PROJECT_ID and DESCOPE_MANAGEMENT_KEY.
+ * Requires DESCOPE_PROJECT_ID and DESCOPE_MANAGEMENT_KEY. Server errors are retried because these
+ * tests replace the project's schema, which is shared with the other live tests.
  */
 class FGALiveTest {
 
@@ -100,7 +102,8 @@ class FGALiveTest {
     }
   }
 
-  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  @RetryingTest(value = 3, suspendForMs = 30000,
+      onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testGdriveSchemaRelationsAndChecks() {
     fgaService.saveSchema(new FGASchema(GDRIVE_SCHEMA));
 
@@ -152,7 +155,8 @@ class FGALiveTest {
     fgaService.deleteRelations(relations);
   }
 
-  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  @RetryingTest(value = 3, suspendForMs = 30000,
+      onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testAbacCheckWithContext() {
     fgaService.saveSchema(new FGASchema(ABAC_SCHEMA));
 
@@ -190,7 +194,8 @@ class FGALiveTest {
     fgaService.deleteRelations(Arrays.asList(viewer));
   }
 
-  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  @RetryingTest(value = 3, suspendForMs = 30000,
+      onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testAbacContextThroughAuthzQueries() {
     fgaService.saveSchema(new FGASchema(ABAC_SCHEMA));
 
@@ -207,7 +212,8 @@ class FGALiveTest {
     fgaService.deleteRelations(Arrays.asList(viewer));
   }
 
-  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  @RetryingTest(value = 3, suspendForMs = 30000,
+      onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testDryRunSchemaDoesNotSave() {
     fgaService.saveSchema(new FGASchema(SIMPLE_SCHEMA));
 
@@ -222,7 +228,8 @@ class FGALiveTest {
     assertTrue(fgaService.loadSchema().getDsl().contains("document"), "dry run must not save the schema");
   }
 
-  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  @RetryingTest(value = 3, suspendForMs = 30000,
+      onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testLoadSchemaReturnsVersionAndConditions() {
     fgaService.saveSchema(new FGASchema(ABAC_SCHEMA));
 
@@ -233,7 +240,8 @@ class FGALiveTest {
         "IsAdmin condition should be returned");
   }
 
-  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  @RetryingTest(value = 3, suspendForMs = 30000,
+      onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testFgaCacheUrlPointingAtTheApiHostStillWorks() {
     Client client = TestUtils.getClient();
     // Not a real cache, but it proves the config reaches the request and the six routed calls
@@ -252,7 +260,8 @@ class FGALiveTest {
     cachedFga.deleteRelations(Arrays.asList(relation));
   }
 
-  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  @RetryingTest(value = 3, suspendForMs = 30000,
+      onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testBadFgaCacheUrlFailsOnlyTheRoutedCalls() {
     fgaService.saveSchema(new FGASchema(SIMPLE_SCHEMA));
 
@@ -282,7 +291,8 @@ class FGALiveTest {
     assertNotNull(badAuthz.resourceRelations("doc1"));
   }
 
-  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  @RetryingTest(value = 3, suspendForMs = 30000,
+      onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testAgainstRealFgaCache() {
     String fgaCacheUrl = EnvironmentUtils.getFgaCacheURL();
     assumeTrue(StringUtils.isNotBlank(fgaCacheUrl), "DESCOPE_FGA_CACHE_URL is not set");

--- a/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
@@ -266,6 +266,7 @@ class FGALiveTest {
       onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testAgainstRealFgaCache() {
     String fgaCacheUrl = EnvironmentUtils.getFgaCacheURL();
+    // Reports as skipped, not failed, when no cache URL is configured.
     assumeTrue(StringUtils.isNotBlank(fgaCacheUrl), "DESCOPE_FGA_CACHE_URL is not set");
 
     Client client = TestUtils.getClient();

--- a/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
@@ -1,0 +1,314 @@
+package com.descope.sdk.mgmt.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.descope.exception.RateLimitExceededException;
+import com.descope.model.client.Client;
+import com.descope.model.fga.FGACheckResult;
+import com.descope.model.fga.FGARelation;
+import com.descope.model.fga.FGAResourceDetails;
+import com.descope.model.fga.FGAResourceIdentifier;
+import com.descope.model.fga.FGASchema;
+import com.descope.model.fga.FGASchemaDryRunResponse;
+import com.descope.model.mgmt.ManagementServices;
+import com.descope.sdk.TestUtils;
+import com.descope.sdk.mgmt.AuthzService;
+import com.descope.sdk.mgmt.FGAService;
+import com.descope.utils.EnvironmentUtils;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junitpioneer.jupiter.RetryingTest;
+
+/**
+ * Live coverage for the FGA surface, mirroring integrationtests/tests/fga_test.go.
+ * Requires DESCOPE_PROJECT_ID and DESCOPE_MANAGEMENT_KEY.
+ */
+class FGALiveTest {
+
+  private static final String GDRIVE_SCHEMA = "model AuthZ 1.0\n"
+      + "\n"
+      + "type user\n"
+      + "\n"
+      + "type group\n"
+      + "  relation member: user\n"
+      + "\n"
+      + "type doc\n"
+      + "  relation owner: user | group#member\n"
+      + "  relation parent: folder\n"
+      + "\n"
+      + "  permission can_create: owner | parent.owner\n"
+      + "\n"
+      + "type folder\n"
+      + "  relation parent: folder\n"
+      + "  relation owner: user | group#member\n"
+      + "  relation editor: user\n"
+      + "\n"
+      + "  permission can_create: owner | parent.owner\n"
+      + "  permission can_edit: editor | parent.editor | can_create\n";
+
+  private static final String ABAC_SCHEMA = "model AuthZ 1.0\n"
+      + "\n"
+      + "condition IsAdmin(role string) { role == \"admin\" }\n"
+      + "condition CanEdit(action string) { action == \"write\" }\n"
+      + "\n"
+      + "type user\n"
+      + "\n"
+      + "type doc\n"
+      + "  relation viewer: user with IsAdmin\n"
+      + "  permission can_edit: viewer with CanEdit\n";
+
+  private static final String SIMPLE_SCHEMA = "model AuthZ 1.0\n"
+      + "\n"
+      + "type user\n"
+      + "\n"
+      + "type document\n"
+      + "  relation viewer: user\n"
+      + "\n"
+      + "  permission can_view: viewer\n";
+
+  private static final String REDUCED_SCHEMA = "model AuthZ 1.0\n"
+      + "\n"
+      + "type user\n";
+
+  private FGAService fgaService;
+  private AuthzService authzService;
+
+  @BeforeEach
+  void setUp() {
+    ManagementServices services = ManagementServiceBuilder.buildServices(TestUtils.getClient());
+    fgaService = services.getFgaService();
+    authzService = services.getAuthzService();
+  }
+
+  @AfterEach
+  void tearDown() {
+    try {
+      authzService.deleteSchema();
+    } catch (Exception ignored) {
+      // The schema may already be gone, nothing to clean up.
+    }
+  }
+
+  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  void testGdriveSchemaRelationsAndChecks() {
+    fgaService.saveSchema(new FGASchema(GDRIVE_SCHEMA));
+
+    List<FGARelation> relations = Arrays.asList(
+        new FGARelation("folder1", "folder", "owner", "u1", "user"),
+        new FGARelation("folder1", "folder", "editor", "u2", "user"),
+        new FGARelation("folder1", "folder", "parent", "rootFolder", "folder"),
+        new FGARelation("rootFolder", "folder", "owner", "u9", "user"),
+        new FGARelation("group1", "group", "member", "ug1", "user"),
+        new FGARelation("group1", "group", "member", "ug2", "user"),
+        new FGARelation("folder2", "folder", "owner", "group1", "group#member"),
+        new FGARelation("folder2", "folder", "owner", "u1", "user"),
+        new FGARelation("folder2", "folder", "parent", "rootFolder", "folder"));
+    fgaService.createRelations(relations);
+
+    List<FGACheckResult> expected = Arrays.asList(
+        expect("folder1", "owner", "u1", true),
+        expect("folder1", "editor", "u2", true),
+        expect("folder1", "editor", "u1", false),
+        expect("folder1", "can_create", "u1", true),
+        expect("folder1", "can_create", "u2", false),
+        expect("folder1", "can_create", "u9", true),
+        expect("folder1", "can_edit", "u2", true),
+        expect("folder1", "can_edit", "u1", true),
+        expect("folder1", "can_edit", "u3", false),
+        expect("folder1", "can_edit", "u9", true),
+        expect("folder1", "owner", "u9", false),
+        expect("rootFolder", "can_edit", "u1", false),
+        expect("folder2", "owner", "ug1", true),
+        expect("folder2", "owner", "u1", true),
+        expect("folder2", "can_create", "ug1", true),
+        expect("folder2", "can_edit", "ug1", true),
+        expect("folder2", "can_edit", "u9", true));
+
+    List<FGARelation> toCheck = new ArrayList<>();
+    for (FGACheckResult check : expected) {
+      toCheck.add(check.getRelation());
+    }
+
+    List<FGACheckResult> results = fgaService.check(toCheck);
+
+    assertEquals(expected.size(), results.size());
+    for (int i = 0; i < expected.size(); i++) {
+      FGARelation relation = expected.get(i).getRelation();
+      assertEquals(expected.get(i).isAllowed(), results.get(i).isAllowed(), "check " + relation);
+      assertEquals(relation, results.get(i).getRelation());
+    }
+
+    fgaService.deleteRelations(relations);
+  }
+
+  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  void testAbacCheckWithContext() {
+    fgaService.saveSchema(new FGASchema(ABAC_SCHEMA));
+
+    FGARelation viewer = new FGARelation("doc1", "doc", "viewer", "u1", "user");
+    fgaService.createRelations(Arrays.asList(viewer));
+
+    List<FGACheckResult> allowed = fgaService.check(Arrays.asList(viewer), contextOf("role", "admin"));
+    assertEquals(1, allowed.size());
+    assertTrue(allowed.get(0).isAllowed(), "admin role should be allowed");
+    assertTrue(allowed.get(0).getInfo().isConditional(), "result should be marked conditional");
+    assertEquals(viewer, allowed.get(0).getRelation());
+
+    List<FGACheckResult> denied = fgaService.check(Arrays.asList(viewer), contextOf("role", "user"));
+    assertFalse(denied.get(0).isAllowed(), "non-admin role should be denied");
+    assertTrue(denied.get(0).getInfo().isConditional());
+
+    List<FGACheckResult> noContext = fgaService.check(Arrays.asList(viewer));
+    assertFalse(noContext.get(0).isAllowed());
+    assertTrue(noContext.get(0).getInfo().getMissingContext().contains("role"),
+        "role should be reported as missing context");
+
+    FGARelation canEdit = new FGARelation("doc1", "doc", "can_edit", "u1", "user");
+    Map<String, Object> writeContext = contextOf("role", "admin");
+    writeContext.put("action", "write");
+    List<FGACheckResult> editAllowed = fgaService.check(Arrays.asList(canEdit), writeContext);
+    assertTrue(editAllowed.get(0).isAllowed(), "admin with write action should be allowed via can_edit");
+    assertTrue(editAllowed.get(0).getInfo().isConditional());
+
+    Map<String, Object> readContext = contextOf("role", "admin");
+    readContext.put("action", "read");
+    List<FGACheckResult> editDenied = fgaService.check(Arrays.asList(canEdit), readContext);
+    assertFalse(editDenied.get(0).isAllowed(), "admin with read action should be denied via can_edit");
+    assertTrue(editDenied.get(0).getInfo().isConditional());
+
+    fgaService.deleteRelations(Arrays.asList(viewer));
+  }
+
+  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  void testAbacContextThroughAuthzQueries() {
+    fgaService.saveSchema(new FGASchema(ABAC_SCHEMA));
+
+    FGARelation viewer = new FGARelation("doc1", "doc", "viewer", "u1", "user");
+    fgaService.createRelations(Arrays.asList(viewer));
+
+    assertTrue(authzService.whoCanAccess("doc1", "viewer", "doc", contextOf("role", "admin")).contains("u1"),
+        "admin role should satisfy the viewer condition");
+    assertFalse(authzService.whoCanAccess("doc1", "viewer", "doc", contextOf("role", "user")).contains("u1"),
+        "non-admin role should not satisfy the viewer condition");
+
+    assertNotNull(authzService.whatCanTargetAccess("u1", contextOf("role", "admin")));
+
+    fgaService.deleteRelations(Arrays.asList(viewer));
+  }
+
+  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  void testDryRunSchemaDoesNotSave() {
+    fgaService.saveSchema(new FGASchema(SIMPLE_SCHEMA));
+
+    FGASchemaDryRunResponse deleting = fgaService.dryRunSchema(new FGASchema(REDUCED_SCHEMA));
+    assertNotNull(deleting.getDeletesPreview());
+    assertTrue(deleting.getDeletesPreview().isHasDeletes(), "dropping the document type should report deletes");
+
+    FGASchemaDryRunResponse unchanged = fgaService.dryRunSchema(new FGASchema(SIMPLE_SCHEMA));
+    assertFalse(unchanged.getDeletesPreview() != null && unchanged.getDeletesPreview().isHasDeletes(),
+        "an unchanged schema should report no deletes");
+
+    assertTrue(fgaService.loadSchema().getDsl().contains("document"), "dry run must not save the schema");
+  }
+
+  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  void testLoadSchemaReturnsVersionAndConditions() {
+    fgaService.saveSchema(new FGASchema(ABAC_SCHEMA));
+
+    FGASchema loaded = fgaService.loadSchema();
+    assertTrue(StringUtils.isNotBlank(loaded.getVersion()), "schema version should be returned");
+    assertNotNull(loaded.getConditions());
+    assertTrue(loaded.getConditions().stream().anyMatch(c -> "IsAdmin".equals(c.getName())),
+        "IsAdmin condition should be returned");
+  }
+
+  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  void testFgaCacheUrlPointingAtTheApiHostStillWorks() {
+    Client client = TestUtils.getClient();
+    // Not a real cache, but it proves the config reaches the request and the six routed calls
+    // keep working through it. The trailing slash covers the URL normalization.
+    client.setFgaCacheUri(client.getUri() + "/");
+    FGAService cachedFga = ManagementServiceBuilder.buildServices(client).getFgaService();
+
+    cachedFga.saveSchema(new FGASchema(SIMPLE_SCHEMA));
+    FGARelation relation = new FGARelation("doc1", "document", "viewer", "u1", "user");
+    cachedFga.createRelations(Arrays.asList(relation));
+
+    List<FGACheckResult> results = cachedFga.check(Arrays.asList(relation));
+    assertEquals(1, results.size());
+    assertTrue(results.get(0).isAllowed());
+
+    cachedFga.deleteRelations(Arrays.asList(relation));
+  }
+
+  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  void testBadFgaCacheUrlFailsOnlyTheRoutedCalls() {
+    fgaService.saveSchema(new FGASchema(SIMPLE_SCHEMA));
+
+    Client client = TestUtils.getClient();
+    client.setFgaCacheUri("http://localhost:1");
+    ManagementServices services = ManagementServiceBuilder.buildServices(client);
+    FGAService badFga = services.getFgaService();
+    AuthzService badAuthz = services.getAuthzService();
+
+    List<FGARelation> relations = Arrays.asList(new FGARelation("doc1", "document", "viewer", "u1", "user"));
+    Map<String, Object> context = contextOf("role", "admin");
+
+    // Transport failures are not mapped into DescopeException, they propagate as-is.
+    assertThrows(Exception.class, () -> badFga.saveSchema(new FGASchema(SIMPLE_SCHEMA)));
+    assertThrows(Exception.class, () -> badFga.createRelations(relations));
+    assertThrows(Exception.class, () -> badFga.deleteRelations(relations));
+    assertThrows(Exception.class, () -> badFga.check(relations));
+    assertThrows(Exception.class, () -> badFga.check(relations, context));
+    assertThrows(Exception.class, () -> badAuthz.whoCanAccess("doc1", "viewer", "document"));
+    assertThrows(Exception.class, () -> badAuthz.whatCanTargetAccess("u1"));
+
+    List<FGAResourceDetails> details = Arrays.asList(new FGAResourceDetails("doc1", "document", "Doc One"));
+    assertNotNull(badFga.loadSchema().getDsl());
+    assertNotNull(badFga.dryRunSchema(new FGASchema(SIMPLE_SCHEMA)));
+    badFga.saveResourcesDetails(details);
+    assertNotNull(badFga.loadResourcesDetails(Arrays.asList(new FGAResourceIdentifier("doc1", "document"))));
+    assertNotNull(badAuthz.resourceRelations("doc1"));
+  }
+
+  @RetryingTest(value = 3, suspendForMs = 30000, onExceptions = RateLimitExceededException.class)
+  void testAgainstRealFgaCache() {
+    String fgaCacheUrl = EnvironmentUtils.getFgaCacheURL();
+    assumeTrue(StringUtils.isNotBlank(fgaCacheUrl), "DESCOPE_FGA_CACHE_URL is not set");
+
+    Client client = TestUtils.getClient();
+    client.setFgaCacheUri(fgaCacheUrl);
+    FGAService cachedFga = ManagementServiceBuilder.buildServices(client).getFgaService();
+
+    cachedFga.saveSchema(new FGASchema(SIMPLE_SCHEMA));
+    FGARelation relation = new FGARelation("doc1", "document", "viewer", "u1", "user");
+    cachedFga.createRelations(Arrays.asList(relation));
+
+    List<FGACheckResult> results = cachedFga.check(Arrays.asList(relation));
+    assertEquals(1, results.size());
+    assertTrue(results.get(0).isAllowed());
+
+    cachedFga.deleteRelations(Arrays.asList(relation));
+  }
+
+  private static FGACheckResult expect(String resource, String relation, String target, boolean allowed) {
+    return new FGACheckResult(allowed, new FGARelation(resource, "folder", relation, target, "user"), null);
+  }
+
+  private static Map<String, Object> contextOf(String key, Object value) {
+    Map<String, Object> context = new HashMap<>();
+    context.put(key, value);
+    return context;
+  }
+}

--- a/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junitpioneer.jupiter.RetryingTest;
 
@@ -93,10 +93,12 @@ class FGALiveTest {
     authzService = services.getAuthzService();
   }
 
-  @AfterEach
-  void tearDown() {
+  // Cleaning up once, not per test: every test saves the schema it needs, and the project is
+  // shared with the other live tests, so deleting the schema between tests only adds churn.
+  @AfterAll
+  static void deleteSchema() {
     try {
-      authzService.deleteSchema();
+      ManagementServiceBuilder.buildServices(TestUtils.getClient()).getAuthzService().deleteSchema();
     } catch (Exception ignored) {
       // The schema may already be gone, nothing to clean up.
     }
@@ -191,23 +193,17 @@ class FGALiveTest {
     assertFalse(editDenied.get(0).isAllowed(), "admin with read action should be denied via can_edit");
     assertTrue(editDenied.get(0).getInfo().isConditional());
 
-    fgaService.deleteRelations(Arrays.asList(viewer));
-  }
-
-  @RetryingTest(value = 3, suspendForMs = 30000,
-      onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
-  void testAbacContextThroughAuthzQueries() {
-    fgaService.saveSchema(new FGASchema(ABAC_SCHEMA));
-
-    FGARelation viewer = new FGARelation("doc1", "doc", "viewer", "u1", "user");
-    fgaService.createRelations(Arrays.asList(viewer));
-
+    // Same context, through the authz queries that evaluate conditions.
     assertTrue(authzService.whoCanAccess("doc1", "viewer", "doc", contextOf("role", "admin")).contains("u1"),
         "admin role should satisfy the viewer condition");
     assertFalse(authzService.whoCanAccess("doc1", "viewer", "doc", contextOf("role", "user")).contains("u1"),
         "non-admin role should not satisfy the viewer condition");
-
     assertNotNull(authzService.whatCanTargetAccess("u1", contextOf("role", "admin")));
+
+    FGASchema loaded = fgaService.loadSchema();
+    assertTrue(StringUtils.isNotBlank(loaded.getVersion()), "schema version should be returned");
+    assertTrue(loaded.getConditions().stream().anyMatch(c -> "IsAdmin".equals(c.getName())),
+        "IsAdmin condition should be returned");
 
     fgaService.deleteRelations(Arrays.asList(viewer));
   }
@@ -226,18 +222,6 @@ class FGALiveTest {
         "an unchanged schema should report no deletes");
 
     assertTrue(fgaService.loadSchema().getDsl().contains("document"), "dry run must not save the schema");
-  }
-
-  @RetryingTest(value = 3, suspendForMs = 30000,
-      onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
-  void testLoadSchemaReturnsVersionAndConditions() {
-    fgaService.saveSchema(new FGASchema(ABAC_SCHEMA));
-
-    FGASchema loaded = fgaService.loadSchema();
-    assertTrue(StringUtils.isNotBlank(loaded.getVersion()), "schema version should be returned");
-    assertNotNull(loaded.getConditions());
-    assertTrue(loaded.getConditions().stream().anyMatch(c -> "IsAdmin".equals(c.getName())),
-        "IsAdmin condition should be returned");
   }
 
   @RetryingTest(value = 3, suspendForMs = 30000,

--- a/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
@@ -146,7 +146,7 @@ class FGALiveTest {
     for (int i = 0; i < expected.size(); i++) {
       FGARelation relation = expected.get(i).getRelation();
       assertEquals(expected.get(i).isAllowed(), results.get(i).isAllowed(), "check " + relation);
-      assertEquals(relation, results.get(i).getRelation());
+      assertEchoes(relation, results.get(i).getRelation());
     }
 
     fgaService.deleteRelations(relations);
@@ -163,7 +163,7 @@ class FGALiveTest {
     assertEquals(1, allowed.size());
     assertTrue(allowed.get(0).isAllowed(), "admin role should be allowed");
     assertTrue(allowed.get(0).getInfo().isConditional(), "result should be marked conditional");
-    assertEquals(viewer, allowed.get(0).getRelation());
+    assertEchoes(viewer, allowed.get(0).getRelation());
 
     List<FGACheckResult> denied = fgaService.check(Arrays.asList(viewer), contextOf("role", "user"));
     assertFalse(denied.get(0).isAllowed(), "non-admin role should be denied");
@@ -260,10 +260,10 @@ class FGALiveTest {
     client.setFgaCacheUri("http://localhost:1");
     ManagementServices services = ManagementServiceBuilder.buildServices(client);
     FGAService badFga = services.getFgaService();
-    AuthzService badAuthz = services.getAuthzService();
+    final AuthzService badAuthz = services.getAuthzService();
 
     List<FGARelation> relations = Arrays.asList(new FGARelation("doc1", "document", "viewer", "u1", "user"));
-    Map<String, Object> context = contextOf("role", "admin");
+    final Map<String, Object> context = contextOf("role", "admin");
 
     // Transport failures are not mapped into DescopeException, they propagate as-is.
     assertThrows(Exception.class, () -> badFga.saveSchema(new FGASchema(SIMPLE_SCHEMA)));
@@ -300,6 +300,15 @@ class FGALiveTest {
     assertTrue(results.get(0).isAllowed());
 
     cachedFga.deleteRelations(Arrays.asList(relation));
+  }
+
+  // The server echoes the tuple it evaluated, with targetType normalized, so compare the rest.
+  private static void assertEchoes(FGARelation requested, FGARelation echoed) {
+    assertNotNull(echoed);
+    assertEquals(requested.getResource(), echoed.getResource());
+    assertEquals(requested.getResourceType(), echoed.getResourceType());
+    assertEquals(requested.getRelation(), echoed.getRelation());
+    assertEquals(requested.getTarget(), echoed.getTarget());
   }
 
   private static FGACheckResult expect(String resource, String relation, String target, boolean allowed) {

--- a/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.descope.exception.RateLimitExceededException;
 import com.descope.exception.ServerCommonException;
+import com.descope.model.authz.Relation;
 import com.descope.model.client.Client;
 import com.descope.model.fga.FGACheckResult;
 import com.descope.model.fga.FGARelation;
@@ -191,7 +192,10 @@ class FGALiveTest {
     List<String> denied1 = authzService.whoCanAccess("doc1", "viewer", "doc", contextOf("role", "user"));
     assertFalse(denied1 != null && denied1.contains("u1"),
         "non-admin role should not satisfy the viewer condition");
-    assertNotNull(authzService.whatCanTargetAccess("u1", contextOf("role", "admin")));
+    assertTrue(reachesDoc1(authzService.whatCanTargetAccess("u1", contextOf("role", "admin"))),
+        "admin role should reach doc1");
+    assertFalse(reachesDoc1(authzService.whatCanTargetAccess("u1", contextOf("role", "user"))),
+        "non-admin role should not reach doc1");
 
     FGASchema loaded = fgaService.loadSchema();
     assertTrue(StringUtils.isNotBlank(loaded.getVersion()), "schema version should be returned");
@@ -267,6 +271,10 @@ class FGALiveTest {
     Client client = TestUtils.getClient();
     client.setFgaCacheUri(fgaCacheUrl);
     assertRoundTripWorks(client);
+  }
+
+  private static boolean reachesDoc1(List<Relation> relations) {
+    return relations != null && relations.stream().anyMatch(r -> "doc1".equals(r.getResource()));
   }
 
   // Saves a schema, creates a relation and checks it, all through whatever FGA cache the client

--- a/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/FGALiveTest.java
@@ -96,7 +96,7 @@ class FGALiveTest {
   // No schema cleanup on purpose: every test here saves the schema it needs, and the project is
   // shared with the other live tests, some of which read the schema without a null guard.
 
-  @RetryingTest(value = 3, suspendForMs = 30000,
+  @RetryingTest(value = 3, suspendForMs = 10000,
       onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testGdriveSchemaRelationsAndChecks() {
     fgaService.saveSchema(new FGASchema(GDRIVE_SCHEMA));
@@ -149,7 +149,7 @@ class FGALiveTest {
     fgaService.deleteRelations(relations);
   }
 
-  @RetryingTest(value = 3, suspendForMs = 30000,
+  @RetryingTest(value = 3, suspendForMs = 10000,
       onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testAbacCheckWithContext() {
     fgaService.saveSchema(new FGASchema(ABAC_SCHEMA));
@@ -188,7 +188,8 @@ class FGALiveTest {
     // Same context, through the authz queries that evaluate conditions.
     assertTrue(authzService.whoCanAccess("doc1", "viewer", "doc", contextOf("role", "admin")).contains("u1"),
         "admin role should satisfy the viewer condition");
-    assertFalse(authzService.whoCanAccess("doc1", "viewer", "doc", contextOf("role", "user")).contains("u1"),
+    List<String> denied1 = authzService.whoCanAccess("doc1", "viewer", "doc", contextOf("role", "user"));
+    assertFalse(denied1 != null && denied1.contains("u1"),
         "non-admin role should not satisfy the viewer condition");
     assertNotNull(authzService.whatCanTargetAccess("u1", contextOf("role", "admin")));
 
@@ -200,7 +201,7 @@ class FGALiveTest {
     fgaService.deleteRelations(Arrays.asList(viewer));
   }
 
-  @RetryingTest(value = 3, suspendForMs = 30000,
+  @RetryingTest(value = 3, suspendForMs = 10000,
       onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testDryRunSchemaDoesNotSave() {
     fgaService.saveSchema(new FGASchema(SIMPLE_SCHEMA));
@@ -216,27 +217,17 @@ class FGALiveTest {
     assertTrue(fgaService.loadSchema().getDsl().contains("document"), "dry run must not save the schema");
   }
 
-  @RetryingTest(value = 3, suspendForMs = 30000,
+  @RetryingTest(value = 3, suspendForMs = 10000,
       onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testFgaCacheUrlPointingAtTheApiHostStillWorks() {
     Client client = TestUtils.getClient();
     // Not a real cache, but it proves the config reaches the request and the six routed calls
     // keep working through it. The trailing slash covers the URL normalization.
     client.setFgaCacheUri(client.getUri() + "/");
-    FGAService cachedFga = ManagementServiceBuilder.buildServices(client).getFgaService();
-
-    cachedFga.saveSchema(new FGASchema(SIMPLE_SCHEMA));
-    FGARelation relation = new FGARelation("doc1", "document", "viewer", "u1", "user");
-    cachedFga.createRelations(Arrays.asList(relation));
-
-    List<FGACheckResult> results = cachedFga.check(Arrays.asList(relation));
-    assertEquals(1, results.size());
-    assertTrue(results.get(0).isAllowed());
-
-    cachedFga.deleteRelations(Arrays.asList(relation));
+    assertRoundTripWorks(client);
   }
 
-  @RetryingTest(value = 3, suspendForMs = 30000,
+  @RetryingTest(value = 3, suspendForMs = 10000,
       onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testBadFgaCacheUrlFailsOnlyTheRoutedCalls() {
     fgaService.saveSchema(new FGASchema(SIMPLE_SCHEMA));
@@ -267,7 +258,7 @@ class FGALiveTest {
     assertDoesNotThrow(() -> badAuthz.resourceRelations("doc1"));
   }
 
-  @RetryingTest(value = 3, suspendForMs = 30000,
+  @RetryingTest(value = 3, suspendForMs = 10000,
       onExceptions = {RateLimitExceededException.class, ServerCommonException.class})
   void testAgainstRealFgaCache() {
     String fgaCacheUrl = EnvironmentUtils.getFgaCacheURL();
@@ -275,6 +266,12 @@ class FGALiveTest {
 
     Client client = TestUtils.getClient();
     client.setFgaCacheUri(fgaCacheUrl);
+    assertRoundTripWorks(client);
+  }
+
+  // Saves a schema, creates a relation and checks it, all through whatever FGA cache the client
+  // is configured with.
+  private static void assertRoundTripWorks(Client client) {
     FGAService cachedFga = ManagementServiceBuilder.buildServices(client).getFgaService();
 
     cachedFga.saveSchema(new FGASchema(SIMPLE_SCHEMA));


### PR DESCRIPTION
## Related Issues
Verifies: https://github.com/descope/etc/issues/17574

## Related PRs
### Upstream PRs
- https://github.com/descope/descope-java/pull/347
- https://github.com/descope/descope-java/pull/348
- https://github.com/descope/descope-java/pull/349

## In a Nutshell
- Ports `integrationtests/tests/fga_test.go` to the Java SDK
- GDrive schema round trip + all 17 check expectations
- ABAC context cases, including `missingContext`
- Dry-run and ABAC-through-authz
- Cache routing covered positively **and** negatively

## Description
Adds `FGALiveTest`, live coverage for everything the first three PRs added, in the harness the repo already uses (`TestUtils.getClient()` + `@RetryingTest` on rate limits, which CI runs with the project secrets).

Ported from `integrationtests/tests/fga_test.go`: `runFGASchemaTest`'s GDrive schema, its 9 relations and all 17 check expectations, and `TestFGAABACCheckWithContext`'s five assertions (conditional allow, conditional deny, missing context, and a condition on a permission). New on the Java side: dry-run, ABAC context through `whoCanAccess` / `whatCanTargetAccess`, and `loadSchema` returning version and conditions.

Cache routing gets three tiers, because CI cannot reach an authzcache instance:
1. Cache URL pointed at the API host — the whole round trip must still pass, which exercises config -> client -> `getFgaUri` including trailing-slash normalization.
2. Cache URL pointed at a dead port — the six routed calls must fail *and* the non-routed calls on the same client must still succeed. The pair is what proves the routed set is exactly those six.
3. A real cache when `DESCOPE_FGA_CACHE_URL` is set, skipped otherwise.

Last of four stacked PRs — based on #349.

## Must
- [x] Tests
- [x] Documentation (if applicable)

## Note for reviewers

Schemas are saved per-test case and not deleted to avoid clashes with concurrent running CI that all share the same test project ID.
