### PR TITLE
feat(auth): support an auth management key for disabled auth methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,29 @@ var descopeClient = new DescopeClient();
 var descopeClient = new DescopeClient(Config.builder().projectId("Your-project").build());
 ```
 
+### Auth Management Key
+
+Authentication methods whose public access has been disabled can still be used by providing an
+auth management key. When set, it is sent along with every authentication request.
+
+Create one in the [Descope Console](https://app.descope.com/settings/company/managementkeys) with
+either the `Authentication` or `Full Access` scope on the project or company.
+
+```java
+// Initialized after setting the DESCOPE_AUTH_MANAGEMENT_KEY env var
+var descopeClient = new DescopeClient();
+
+// ** Or directly **
+var descopeClient = new DescopeClient(Config.builder()
+        .projectId("Your-project")
+        .authManagementKey("auth-management-key")
+        .build());
+```
+
+**Note**: the auth management key can, and probably should, be a different management key than the
+one provided for [management API usage](#setup-1). The auth management key is never sent on
+management requests, and the management key is never sent on authentication requests.
+
 ## Authentication Functions
 
 These sections show how to use the SDK to perform various authentication/authorization functions:
@@ -606,6 +629,8 @@ in nature. Please use responsibly.
 
 To use the management API you'll need a `Management Key` along with your `Project ID`.
 Create one in the [Descope Console](https://app.descope.com/settings/company/managementkeys).
+This key is used only for management functions - to reach authentication methods whose public
+access has been disabled, use the [Auth Management Key](#auth-management-key) instead.
 
 ```java
 import com.descope.client;
@@ -1922,6 +1947,8 @@ Find your management key in the [Descope console](https://app.descope.com/settin
 ```bash
 export DESCOPE_PROJECT_ID=<ProjectID>
 export DESCOPE_MANAGEMENT_KEY=<ManagementKey>
+# Optional, only needed for authentication methods with disabled public access
+export DESCOPE_AUTH_MANAGEMENT_KEY=<AuthManagementKey>
 ```
 
 Alternatively, you can create a `.env` file in the working folder with your project ID and management key.
@@ -1929,6 +1956,7 @@ Alternatively, you can create a `.env` file in the working folder with your proj
 ```
 DESCOPE_PROJECT_ID=<ProjectID>
 DESCOPE_MANAGEMENT_KEY=<ManagementKey>
+DESCOPE_AUTH_MANAGEMENT_KEY=<AuthManagementKey>
 ```
 
 ### Run an example

--- a/src/main/java/com/descope/client/Config.java
+++ b/src/main/java/com/descope/client/Config.java
@@ -49,10 +49,24 @@ public class Config {
   // FGACacheURL (optional, "") - pass FGA calls through a cache service, if set.
   private String fgaCacheUrl;
 
+  // AuthManagementKey (optional, "") - used to provide a management key to use with
+  // Authentication APIs whose public access has been disabled. It is not used for any of the
+  // Management APIs, and can, and probably should, be a different key than managementKey.
+  // If empty, this value is retrieved from the DESCOPE_AUTH_MANAGEMENT_KEY environment variable
+  // instead. If neither values are set then any disabled authentication method API call will fail.
+  private String authManagementKey;
+
   // Keeps the pre-fgaCacheUrl all-args constructor available to callers that use it positionally.
   public Config(String projectId, String managementKey, String publicKey, String descopeBaseUrl,
       Map<String, String> customDefaultHeaders) {
     this(projectId, managementKey, publicKey, descopeBaseUrl, customDefaultHeaders, null);
+  }
+
+  // Keeps the pre-authManagementKey all-args constructor available to callers that use it
+  // positionally.
+  public Config(String projectId, String managementKey, String publicKey, String descopeBaseUrl,
+      Map<String, String> customDefaultHeaders, String fgaCacheUrl) {
+    this(projectId, managementKey, publicKey, descopeBaseUrl, customDefaultHeaders, fgaCacheUrl, null);
   }
 
   public String initializeProjectId() {
@@ -88,5 +102,12 @@ public class Config {
       this.managementKey = EnvironmentUtils.getManagementKey();
     }
     return this.managementKey;
+  }
+
+  public String initializeAuthManagementKey() {
+    if (StringUtils.isBlank(this.authManagementKey)) {
+      this.authManagementKey = EnvironmentUtils.getAuthManagementKey();
+    }
+    return this.authManagementKey;
   }
 }

--- a/src/main/java/com/descope/client/DescopeClient.java
+++ b/src/main/java/com/descope/client/DescopeClient.java
@@ -49,6 +49,7 @@ public class DescopeClient {
       log.debug("Provided public key is set, forcing only provided public key validation");
     }
     config.initializeManagementKey();
+    config.initializeAuthManagementKey();
     config.initializeBaseURL();
     config.initializeFgaCacheUrl();
 
@@ -71,6 +72,7 @@ public class DescopeClient {
         .fgaCacheUri(config.getFgaCacheUrl())
         .projectId(projectId)
         .managementKey(config.getManagementKey())
+        .authManagementKey(config.getAuthManagementKey())
         .headers(
             Collections.isEmpty(config.getCustomDefaultHeaders())
               ? new HashMap<>() : new HashMap<>(config.getCustomDefaultHeaders()))

--- a/src/main/java/com/descope/literals/AppConstants.java
+++ b/src/main/java/com/descope/literals/AppConstants.java
@@ -7,6 +7,7 @@ public class AppConstants {
   public static final String PROJECT_ID_ENV_VAR = "DESCOPE_PROJECT_ID";
   public static final String PUBLIC_KEY_ENV_VAR = "DESCOPE_PUBLIC_KEY";
   public static final String MANAGEMENT_KEY_ENV_VAR = "DESCOPE_MANAGEMENT_KEY";
+  public static final String AUTH_MANAGEMENT_KEY_ENV_VAR = "DESCOPE_AUTH_MANAGEMENT_KEY";
   public static final String BASE_URL_ENV_VAR = "DESCOPE_BASE_URL";
   public static final String FGA_CACHE_URL_ENV_VAR = "DESCOPE_FGA_CACHE_URL";
   public static final String AUTHORIZATION_HEADER_NAME = "Authorization";

--- a/src/main/java/com/descope/model/client/Client.java
+++ b/src/main/java/com/descope/model/client/Client.java
@@ -25,11 +25,21 @@ public class Client {
   private AtomicReference<Map<String, Key>> keys = new AtomicReference<>(new HashMap<>());
   // When set, FGA calls that the FGA cache serves go here instead of uri.
   private String fgaCacheUri;
+  // When set, sent along with every authentication request so that authentication methods whose
+  // public access has been disabled can still be used. Never sent on management requests.
+  private String authManagementKey;
 
   // Keeps the pre-fgaCacheUri all-args constructor available to callers that use it positionally.
   public Client(String uri, String projectId, String managementKey, Map<String, String> headers,
       SdkInfo sdkInfo, Key providedKey, AtomicReference<Map<String, Key>> keys) {
-    this(uri, projectId, managementKey, headers, sdkInfo, providedKey, keys, null);
+    this(uri, projectId, managementKey, headers, sdkInfo, providedKey, keys, null, null);
+  }
+
+  // Keeps the pre-authManagementKey all-args constructor available to callers that use it
+  // positionally.
+  public Client(String uri, String projectId, String managementKey, Map<String, String> headers,
+      SdkInfo sdkInfo, Key providedKey, AtomicReference<Map<String, Key>> keys, String fgaCacheUri) {
+    this(uri, projectId, managementKey, headers, sdkInfo, providedKey, keys, fgaCacheUri, null);
   }
 
   public Key getKey(String keyId) {

--- a/src/main/java/com/descope/sdk/auth/impl/AuthenticationsBase.java
+++ b/src/main/java/com/descope/sdk/auth/impl/AuthenticationsBase.java
@@ -20,6 +20,7 @@ import com.descope.proxy.ApiProxy;
 import com.descope.proxy.impl.ApiProxyBuilder;
 import com.descope.sdk.SdkServicesBase;
 import com.descope.sdk.auth.AuthenticationService;
+import com.descope.utils.AuthUtils;
 import com.descope.utils.JwtUtils;
 import java.net.URI;
 import java.util.ArrayList;
@@ -36,20 +37,18 @@ abstract class AuthenticationsBase extends SdkServicesBase implements Authentica
   }
 
   ApiProxy getApiProxy() {
-    String projectId = client.getProjectId();
-    if (StringUtils.isNotBlank(projectId)) {
-      return ApiProxyBuilder.buildProxy(() -> "Bearer " + projectId, client);
-    }
-    return ApiProxyBuilder.buildProxy(client.getSdkInfo());
+    return getApiProxy(null);
   }
 
+  // The auth management key, when configured, rides along with every authentication request so
+  // that methods whose public access has been disabled can still be used.
   ApiProxy getApiProxy(String refreshToken) {
     String projectId = client.getProjectId();
-    if (StringUtils.isBlank(refreshToken) || StringUtils.isBlank(projectId)) {
-      return getApiProxy();
+    if (StringUtils.isBlank(projectId)) {
+      return ApiProxyBuilder.buildProxy(client.getSdkInfo());
     }
 
-    String token = String.format("Bearer %s:%s", projectId, refreshToken);
+    String token = AuthUtils.getBearerHeader(projectId, refreshToken, client.getAuthManagementKey());
     return ApiProxyBuilder.buildProxy(() -> token, client);
   }
 

--- a/src/main/java/com/descope/sdk/auth/impl/KeyProvider.java
+++ b/src/main/java/com/descope/sdk/auth/impl/KeyProvider.java
@@ -9,6 +9,7 @@ import com.descope.model.jwt.SigningKey;
 import com.descope.model.jwt.response.SigningKeysResponse;
 import com.descope.proxy.ApiProxy;
 import com.descope.proxy.impl.ApiProxyBuilder;
+import com.descope.utils.AuthUtils;
 import com.descope.utils.UriUtils;
 import java.math.BigInteger;
 import java.net.URI;
@@ -26,7 +27,8 @@ import lombok.experimental.UtilityClass;
 public class KeyProvider {
 
   public static Map<String, Key> getKeys(String projectId, String url, Client client) {
-    ApiProxy apiProxy = ApiProxyBuilder.buildProxy(() -> "Bearer " + projectId, client);
+    String token = AuthUtils.getBearerHeader(projectId, null, client.getAuthManagementKey());
+    ApiProxy apiProxy = ApiProxyBuilder.buildProxy(() -> token, client);
     URI uri = addPath(UriUtils.getUri(url, GET_KEYS_LINK), projectId);
     SigningKeysResponse signingKeys = apiProxy.get(uri, SigningKeysResponse.class);
 

--- a/src/main/java/com/descope/sdk/auth/impl/KeyProvider.java
+++ b/src/main/java/com/descope/sdk/auth/impl/KeyProvider.java
@@ -27,8 +27,7 @@ import lombok.experimental.UtilityClass;
 public class KeyProvider {
 
   public static Map<String, Key> getKeys(String projectId, String url, Client client) {
-    String token = AuthUtils.getBearerHeader(projectId, null, client.getAuthManagementKey());
-    ApiProxy apiProxy = ApiProxyBuilder.buildProxy(() -> token, client);
+    ApiProxy apiProxy = ApiProxyBuilder.buildProxy(() -> AuthUtils.getBearerHeader(projectId), client);
     URI uri = addPath(UriUtils.getUri(url, GET_KEYS_LINK), projectId);
     SigningKeysResponse signingKeys = apiProxy.get(uri, SigningKeysResponse.class);
 

--- a/src/main/java/com/descope/sdk/mgmt/impl/ManagementsBase.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/ManagementsBase.java
@@ -6,6 +6,7 @@ import com.descope.proxy.ApiProxy;
 import com.descope.proxy.impl.ApiProxyBuilder;
 import com.descope.sdk.SdkServicesBase;
 import com.descope.sdk.mgmt.ManagementService;
+import com.descope.utils.AuthUtils;
 import com.descope.utils.UriUtils;
 import java.net.URI;
 import org.apache.commons.lang3.StringUtils;
@@ -17,22 +18,17 @@ abstract class ManagementsBase extends SdkServicesBase implements ManagementServ
   }
 
   ApiProxy getApiProxy() {
-    String projectId = client.getProjectId();
-    String managementKey = client.getManagementKey();
-    if (StringUtils.isNotBlank(projectId)) {
-      return ApiProxyBuilder.buildProxy(
-          () -> String.format("Bearer %s:%s", projectId, managementKey), client);
-    }
-    return ApiProxyBuilder.buildProxy(client.getSdkInfo());
+    return getApiProxy(null);
   }
 
+  // Management requests always carry the management key, never the auth management key.
   ApiProxy getApiProxy(String refreshToken) {
     String projectId = client.getProjectId();
-    if (StringUtils.isBlank(refreshToken) || StringUtils.isNotBlank(projectId)) {
-      return getApiProxy();
+    if (StringUtils.isBlank(projectId)) {
+      return ApiProxyBuilder.buildProxy(client.getSdkInfo());
     }
 
-    String token = String.format("Bearer %s:%s", projectId, refreshToken);
+    String token = AuthUtils.getBearerHeader(projectId, refreshToken, client.getManagementKey());
     return ApiProxyBuilder.buildProxy(() -> token, client);
   }
 
@@ -40,7 +36,7 @@ abstract class ManagementsBase extends SdkServicesBase implements ManagementServ
     if (StringUtils.isBlank(bearerJwt)) {
       throw ServerCommonException.invalidArgument("bearerJwt");
     }
-    String token = String.format("Bearer %s", bearerJwt);
+    String token = AuthUtils.getBearerHeader(bearerJwt);
     return ApiProxyBuilder.buildProxy(() -> token, client);
   }
 

--- a/src/main/java/com/descope/utils/AuthUtils.java
+++ b/src/main/java/com/descope/utils/AuthUtils.java
@@ -1,0 +1,31 @@
+package com.descope.utils;
+
+import static com.descope.literals.AppConstants.BEARER_AUTHORIZATION_PREFIX;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
+
+@UtilityClass
+public class AuthUtils {
+
+  /**
+   * Builds an {@code Authorization} header value out of the given parts, joined with a colon and
+   * prefixed with {@code Bearer }. Blank parts are skipped, so callers can pass optional values
+   * without branching.
+   *
+   * <p>The canonical order is project ID, then a token (refresh JWT or access key), then a
+   * management key, producing values such as {@code Bearer <projectId>},
+   * {@code Bearer <projectId>:<managementKey>} or
+   * {@code Bearer <projectId>:<refreshJwt>:<managementKey>}.
+   *
+   * @param parts the header parts, in order, any of which may be null or blank
+   * @return the header value
+   */
+  public static String getBearerHeader(String... parts) {
+    return BEARER_AUTHORIZATION_PREFIX + Arrays.stream(parts)
+        .filter(StringUtils::isNotBlank)
+        .collect(Collectors.joining(":"));
+  }
+}

--- a/src/main/java/com/descope/utils/EnvironmentUtils.java
+++ b/src/main/java/com/descope/utils/EnvironmentUtils.java
@@ -1,5 +1,6 @@
 package com.descope.utils;
 
+import static com.descope.literals.AppConstants.AUTH_MANAGEMENT_KEY_ENV_VAR;
 import static com.descope.literals.AppConstants.BASE_URL_ENV_VAR;
 import static com.descope.literals.AppConstants.FGA_CACHE_URL_ENV_VAR;
 import static com.descope.literals.AppConstants.MANAGEMENT_KEY_ENV_VAR;
@@ -31,5 +32,9 @@ public class EnvironmentUtils {
 
   public static String getManagementKey() {
     return dotenv.get(MANAGEMENT_KEY_ENV_VAR);
+  }
+
+  public static String getAuthManagementKey() {
+    return dotenv.get(AUTH_MANAGEMENT_KEY_ENV_VAR);
   }
 }

--- a/src/test/java/com/descope/client/DescopeClientTest.java
+++ b/src/test/java/com/descope/client/DescopeClientTest.java
@@ -1,5 +1,6 @@
 package com.descope.client;
 
+import static com.descope.literals.AppConstants.AUTH_MANAGEMENT_KEY_ENV_VAR;
 import static com.descope.literals.AppConstants.MANAGEMENT_KEY_ENV_VAR;
 import static com.descope.literals.AppConstants.PROJECT_ID_ENV_VAR;
 import static com.descope.literals.AppConstants.PUBLIC_KEY_ENV_VAR;
@@ -115,6 +116,53 @@ class DescopeClientTest {
         Assertions.assertThat(u).isNotNull();
       }
     });
+  }
+
+  @Test
+  void testAuthManagementKeyFromEnvVariable() throws Exception {
+    String expectedProjectID = "P123456789012345678901234567";
+    EnvironmentVariables env =
+        new EnvironmentVariables(PROJECT_ID_ENV_VAR, expectedProjectID)
+            .and(MANAGEMENT_KEY_ENV_VAR, "someManagementKey")
+            .and(AUTH_MANAGEMENT_KEY_ENV_VAR, "someAuthManagementKey");
+    env.execute(
+        () -> {
+          Config config = new DescopeClient().getConfig();
+          Assertions.assertThat(config.getAuthManagementKey()).isEqualTo("someAuthManagementKey");
+          // The two keys serve different purposes and must stay distinct
+          Assertions.assertThat(config.getManagementKey()).isEqualTo("someManagementKey");
+        });
+  }
+
+  @Test
+  void testAuthManagementKeyFromConfigTakesPrecedence() throws Exception {
+    String expectedProjectID = "P123456789012345678901234567";
+    EnvironmentVariables env =
+        new EnvironmentVariables(PROJECT_ID_ENV_VAR, expectedProjectID)
+            .and(AUTH_MANAGEMENT_KEY_ENV_VAR, "envAuthManagementKey");
+    env.execute(
+        () -> {
+          Config config = new DescopeClient(
+              Config.builder()
+                  .projectId(expectedProjectID)
+                  .authManagementKey("configAuthManagementKey")
+                  .build()).getConfig();
+          Assertions.assertThat(config.getAuthManagementKey()).isEqualTo("configAuthManagementKey");
+        });
+  }
+
+  @Test
+  void testAuthManagementKeyDefaultsToBlank() throws Exception {
+    String expectedProjectID = "P123456789012345678901234567";
+    EnvironmentVariables env =
+        new EnvironmentVariables(PROJECT_ID_ENV_VAR, expectedProjectID)
+            .and(MANAGEMENT_KEY_ENV_VAR, "someManagementKey")
+            .and(AUTH_MANAGEMENT_KEY_ENV_VAR, "");
+    env.execute(
+        () -> {
+          Config config = new DescopeClient().getConfig();
+          Assertions.assertThat(config.getAuthManagementKey()).isNullOrEmpty();
+        });
   }
 
   @Test

--- a/src/test/java/com/descope/sdk/auth/impl/AuthenticationsBaseTest.java
+++ b/src/test/java/com/descope/sdk/auth/impl/AuthenticationsBaseTest.java
@@ -1,0 +1,86 @@
+package com.descope.sdk.auth.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import com.descope.model.client.Client;
+import com.descope.model.client.SdkInfo;
+import com.descope.proxy.ApiProxy;
+import com.descope.proxy.impl.ApiProxyBuilder;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Covers the Authorization header that authentication requests carry, and in particular that the
+ * auth management key rides along with them while the management key never does.
+ */
+class AuthenticationsBaseTest {
+
+  private static final String PROJECT_ID = "P123456789012345678901234567";
+  private static final String MANAGEMENT_KEY = "some-management-key";
+  private static final String AUTH_MANAGEMENT_KEY = "some-auth-management-key";
+  private static final String REFRESH_TOKEN = "some-refresh-token";
+
+  @Test
+  void testNoAuthManagementKey() {
+    assertThat(authHeader(client(null, null), AuthenticationsBase::getApiProxy))
+        .isEqualTo("Bearer " + PROJECT_ID);
+  }
+
+  @Test
+  void testWithAuthManagementKey() {
+    assertThat(authHeader(client(null, AUTH_MANAGEMENT_KEY), AuthenticationsBase::getApiProxy))
+        .isEqualTo("Bearer " + PROJECT_ID + ":" + AUTH_MANAGEMENT_KEY);
+  }
+
+  @Test
+  void testWithRefreshTokenAndAuthManagementKey() {
+    assertThat(authHeader(client(null, AUTH_MANAGEMENT_KEY), base -> base.getApiProxy(REFRESH_TOKEN)))
+        .isEqualTo("Bearer " + PROJECT_ID + ":" + REFRESH_TOKEN + ":" + AUTH_MANAGEMENT_KEY);
+  }
+
+  @Test
+  void testWithRefreshTokenOnly() {
+    assertThat(authHeader(client(null, null), base -> base.getApiProxy(REFRESH_TOKEN)))
+        .isEqualTo("Bearer " + PROJECT_ID + ":" + REFRESH_TOKEN);
+  }
+
+  @Test
+  void testManagementKeyIsNeverSentOnAuthRequests() {
+    assertThat(authHeader(client(MANAGEMENT_KEY, null), AuthenticationsBase::getApiProxy))
+        .isEqualTo("Bearer " + PROJECT_ID);
+    assertThat(authHeader(client(MANAGEMENT_KEY, AUTH_MANAGEMENT_KEY), AuthenticationsBase::getApiProxy))
+        .isEqualTo("Bearer " + PROJECT_ID + ":" + AUTH_MANAGEMENT_KEY);
+  }
+
+  private static Client client(String managementKey, String authManagementKey) {
+    return Client.builder()
+        .uri("https://api.descope.com")
+        .projectId(PROJECT_ID)
+        .managementKey(managementKey)
+        .authManagementKey(authManagementKey)
+        .sdkInfo(SdkInfo.builder().name("java").build())
+        .build();
+  }
+
+  /** Runs the given call against an auth service and returns the Authorization header it built. */
+  @SuppressWarnings("unchecked")
+  private static String authHeader(Client client, Function<AuthenticationsBase, ApiProxy> call) {
+    AuthenticationsBase base =
+        (AuthenticationsBase) AuthenticationServiceBuilder.buildServices(client).getOtpService();
+    AtomicReference<String> captured = new AtomicReference<>();
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenAnswer(inv -> {
+        captured.set(((Supplier<String>) inv.getArgument(0)).get());
+        return mock(ApiProxy.class);
+      });
+      call.apply(base);
+    }
+    return captured.get();
+  }
+}

--- a/src/test/java/com/descope/sdk/mgmt/impl/ManagementsBaseTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/ManagementsBaseTest.java
@@ -1,0 +1,73 @@
+package com.descope.sdk.mgmt.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import com.descope.model.client.Client;
+import com.descope.model.client.SdkInfo;
+import com.descope.proxy.ApiProxy;
+import com.descope.proxy.impl.ApiProxyBuilder;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Mirror of AuthenticationsBaseTest: management requests carry the management key and must never
+ * carry the auth management key.
+ */
+class ManagementsBaseTest {
+
+  private static final String PROJECT_ID = "P123456789012345678901234567";
+  private static final String MANAGEMENT_KEY = "some-management-key";
+  private static final String AUTH_MANAGEMENT_KEY = "some-auth-management-key";
+
+  @Test
+  void testManagementKeyIsSent() {
+    assertThat(authHeader(client(MANAGEMENT_KEY, null), ManagementsBase::getApiProxy))
+        .isEqualTo("Bearer " + PROJECT_ID + ":" + MANAGEMENT_KEY);
+  }
+
+  @Test
+  void testAuthManagementKeyIsNeverSentOnManagementRequests() {
+    assertThat(authHeader(client(MANAGEMENT_KEY, AUTH_MANAGEMENT_KEY), ManagementsBase::getApiProxy))
+        .isEqualTo("Bearer " + PROJECT_ID + ":" + MANAGEMENT_KEY);
+    assertThat(authHeader(client(null, AUTH_MANAGEMENT_KEY), ManagementsBase::getApiProxy))
+        .isEqualTo("Bearer " + PROJECT_ID);
+  }
+
+  @Test
+  void testBearerOnlyProxy() {
+    assertThat(authHeader(client(MANAGEMENT_KEY, null), base -> base.getApiProxyWithBearer("a-jwt")))
+        .isEqualTo("Bearer a-jwt");
+  }
+
+  private static Client client(String managementKey, String authManagementKey) {
+    return Client.builder()
+        .uri("https://api.descope.com")
+        .projectId(PROJECT_ID)
+        .managementKey(managementKey)
+        .authManagementKey(authManagementKey)
+        .sdkInfo(SdkInfo.builder().name("java").build())
+        .build();
+  }
+
+  /** Runs the given call against a management service and returns the header it built. */
+  @SuppressWarnings("unchecked")
+  private static String authHeader(Client client, Function<ManagementsBase, ApiProxy> call) {
+    ManagementsBase base =
+        (ManagementsBase) ManagementServiceBuilder.buildServices(client).getTenantService();
+    AtomicReference<String> captured = new AtomicReference<>();
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenAnswer(inv -> {
+        captured.set(((Supplier<String>) inv.getArgument(0)).get());
+        return mock(ApiProxy.class);
+      });
+      call.apply(base);
+    }
+    return captured.get();
+  }
+}

--- a/src/test/java/com/descope/utils/AuthUtilsTest.java
+++ b/src/test/java/com/descope/utils/AuthUtilsTest.java
@@ -1,0 +1,49 @@
+package com.descope.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AuthUtilsTest {
+
+  private static final String PROJECT_ID = "P123456789012345678901234567";
+  private static final String TOKEN = "some-refresh-token";
+  private static final String KEY = "some-management-key";
+
+  @Test
+  void testProjectIdOnly() {
+    assertThat(AuthUtils.getBearerHeader(PROJECT_ID)).isEqualTo("Bearer " + PROJECT_ID);
+    assertThat(AuthUtils.getBearerHeader(PROJECT_ID, null, null)).isEqualTo("Bearer " + PROJECT_ID);
+  }
+
+  @Test
+  void testProjectIdAndKey() {
+    assertThat(AuthUtils.getBearerHeader(PROJECT_ID, null, KEY))
+        .isEqualTo("Bearer " + PROJECT_ID + ":" + KEY);
+  }
+
+  @Test
+  void testProjectIdAndToken() {
+    assertThat(AuthUtils.getBearerHeader(PROJECT_ID, TOKEN, null))
+        .isEqualTo("Bearer " + PROJECT_ID + ":" + TOKEN);
+  }
+
+  @Test
+  void testAllParts() {
+    assertThat(AuthUtils.getBearerHeader(PROJECT_ID, TOKEN, KEY))
+        .isEqualTo("Bearer " + PROJECT_ID + ":" + TOKEN + ":" + KEY);
+  }
+
+  @Test
+  void testBlankPartsAreSkipped() {
+    assertThat(AuthUtils.getBearerHeader(PROJECT_ID, "", "   ", KEY))
+        .isEqualTo("Bearer " + PROJECT_ID + ":" + KEY);
+    assertThat(AuthUtils.getBearerHeader("", TOKEN)).isEqualTo("Bearer " + TOKEN);
+  }
+
+  @Test
+  void testNoParts() {
+    assertThat(AuthUtils.getBearerHeader()).isEqualTo("Bearer ");
+    assertThat(AuthUtils.getBearerHeader(null, null)).isEqualTo("Bearer ");
+  }
+}


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/8683

## Description

- Add an optional `authManagementKey` to `Config`, resolved from `DESCOPE_AUTH_MANAGEMENT_KEY` when not set explicitly, and sent with every authentication request so methods with disabled public access can be used
- Extract bearer assembly into `AuthUtils.getBearerHeader` and route `AuthenticationsBase`, `ManagementsBase` and `KeyProvider` through it, replacing the duplicated `String.format("Bearer %s:%s", ...)` literals
- Two incidental cleanups in `ManagementsBase`, both on paths with no call sites: an inverted `isNotBlank(projectId)` guard made the refresh-token branch dead code, and a blank management key emitted a trailing-colon `Bearer <projectId>:`

## Must

- [x] Tests
- [x] Documentation