### PR TITLE
fix(mgmt): add failoncontrol support for update email and phone

Wait, l

### DIFF
--- a/src/main/java/com/descope/sdk/mgmt/UserService.java
+++ b/src/main/java/com/descope/sdk/mgmt/UserService.java
@@ -240,6 +240,22 @@ public interface UserService {
    * Update the email address for an existing user.
    *
    * @param loginId The loginID is required.
+   * @param email The email parameter can be empty in which case the email will be removed.
+   * @param isVerified The isVerified flag must be true for the user to be able to login with the
+   *     email address.
+   * @param failOnConflict If true, the call will fail with an error instead of silently deleting
+   *     and merging another user that already has this email address.
+   * @return {@link UserResponseDetails UserResponseDetails}
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be
+   *     thrown.
+   */
+  UserResponseDetails updateEmail(String loginId, String email, Boolean isVerified, Boolean failOnConflict)
+      throws DescopeException;
+
+  /**
+   * Update the email address for an existing user.
+   *
+   * @param loginId The loginID is required.
    * @param phone The phone parameter can be empty in which case the phone will be removed.
    * @param isVerified The isVerified flag must be true for the user to be able to login with the
    *     email address.
@@ -248,6 +264,22 @@ public interface UserService {
    *     thrown.
    */
   UserResponseDetails updatePhone(String loginId, String phone, Boolean isVerified)
+      throws DescopeException;
+
+  /**
+   * Update the email address for an existing user.
+   *
+   * @param loginId The loginID is required.
+   * @param phone The phone parameter can be empty in which case the phone will be removed.
+   * @param isVerified The isVerified flag must be true for the user to be able to login with the
+   *     email address.
+   * @param failOnConflict If true, the call will fail with an error instead of silently deleting
+   *     and merging another user that already has this phone number.
+   * @return {@link UserResponseDetails UserResponseDetails}
+   * @throws DescopeException If there occurs any exception, a subtype of this exception will be
+   *     thrown.
+   */
+  UserResponseDetails updatePhone(String loginId, String phone, Boolean isVerified, Boolean failOnConflict)
       throws DescopeException;
 
   /**

--- a/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/UserServiceImpl.java
@@ -382,22 +382,36 @@ class UserServiceImpl extends ManagementsBase implements UserService {
 
   @Override
   public UserResponseDetails updateEmail(String loginId, String email, Boolean isVerified) throws DescopeException {
+    return updateEmail(loginId, email, isVerified, null);
+  }
+
+  @Override
+  public UserResponseDetails updateEmail(String loginId, String email, Boolean isVerified, Boolean failOnConflict)
+      throws DescopeException {
     if (StringUtils.isBlank(loginId)) {
       throw ServerCommonException.invalidArgument("Login ID");
     }
     URI updateEmailUri = composeUpdateEmailUri();
     Map<String, Object> request = mapOf("loginId", loginId, "email", email, "verified", isVerified);
+    addIfNotNull(request, "failOnConflict", failOnConflict);
     ApiProxy apiProxy = getApiProxy();
     return apiProxy.post(updateEmailUri, request, UserResponseDetails.class);
   }
 
   @Override
   public UserResponseDetails updatePhone(String loginId, String phone, Boolean isVerified) throws DescopeException {
+    return updatePhone(loginId, phone, isVerified, null);
+  }
+
+  @Override
+  public UserResponseDetails updatePhone(String loginId, String phone, Boolean isVerified, Boolean failOnConflict)
+      throws DescopeException {
     if (StringUtils.isBlank(loginId)) {
       throw ServerCommonException.invalidArgument("Login ID");
     }
     URI updatePhoneUri = composeUpdatePhoneUri();
     Map<String, Object> request = mapOf("loginId", loginId, "phone", phone, "verified", isVerified);
+    addIfNotNull(request, "failOnConflict", failOnConflict);
     ApiProxy apiProxy = getApiProxy();
     return apiProxy.post(updatePhoneUri, request, UserResponseDetails.class);
   }

--- a/src/test/java/com/descope/sdk/mgmt/impl/UserServiceImplTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/UserServiceImplTest.java
@@ -72,6 +72,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.RetryingTest;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 public class UserServiceImplTest {
@@ -368,6 +369,21 @@ public class UserServiceImplTest {
   }
 
   @Test
+  void testUpdateEmailWithFailOnConflictForSuccess() {
+    UserResponseDetails userResponseDetails = mock(UserResponseDetails.class);
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(userResponseDetails).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      UserResponseDetails response = userService.updateEmail("someLoginId", "someEmail", false, true);
+      Assertions.assertThat(response).isNotNull();
+      ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+      verify(apiProxy).post(any(), captor.capture(), any());
+      assertEquals(true, captor.getValue().get("failOnConflict"));
+    }
+  }
+
+  @Test
   void testUpdatePhoneForEmptyLoginId() {
     ServerCommonException thrown = assertThrows(ServerCommonException.class,
         () -> userService.updatePhone("", "someEmail", false));
@@ -384,6 +400,21 @@ public class UserServiceImplTest {
       mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
       UserResponseDetails response = userService.updatePhone("someLoginId", "1234567890", false);
       Assertions.assertThat(response).isNotNull();
+    }
+  }
+
+  @Test
+  void testUpdatePhoneWithFailOnConflictForSuccess() {
+    UserResponseDetails userResponseDetails = mock(UserResponseDetails.class);
+    ApiProxy apiProxy = mock(ApiProxy.class);
+    doReturn(userResponseDetails).when(apiProxy).post(any(), any(), any());
+    try (MockedStatic<ApiProxyBuilder> mockedApiProxyBuilder = mockStatic(ApiProxyBuilder.class)) {
+      mockedApiProxyBuilder.when(() -> ApiProxyBuilder.buildProxy(any(), any())).thenReturn(apiProxy);
+      UserResponseDetails response = userService.updatePhone("someLoginId", "1234567890", false, true);
+      Assertions.assertThat(response).isNotNull();
+      ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+      verify(apiProxy).post(any(), captor.capture(), any());
+      assertEquals(true, captor.getValue().get("failOnConflict"));
     }
   }
 


### PR DESCRIPTION
Fixes descope/etc#17716

[View Shuni run](https://shuni.descope.ai/sessions?sandbox=i0gn65bo5d13kcnytiai4)

Fixed. Summary:

- Added `failOnConflict` overloads to `UserService.updateEmail`/`updatePhone` (interface) and their implementations in `UserServiceImpl.java`, following the existing overload-delegation convention already used in this file (e.g. `generateEmbeddedLink`). The 3-arg methods delegate to the new 4-arg ones passing `null`, so existing callers are unaffected; when explicitly set, `failOnConflict` is added to the REST request body via `addIfNotNull`.
- Added unit tests (`testUpdateEmailWithFailOnConflictForSuccess`, `testUpdatePhoneWithFailOnConflictForSuccess`) that capture the outgoing request map and assert `failOnConflict` is sent correctly.
- Verified with `mvn checkstyle:check`, `mvn test` (all `UserServiceImplTest` unit tests pass; the 10 pre-existing `testFunctional*` failures are unrelated — they require live `DESCOPE_PROJECT_ID`/`DESCOPE_MANAGEMENT_KEY` credentials), and `mvn package`.
- Committed as `24590fd`.

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*