### PR TITLE
feat(mgmt): send rate limit tier in license header

### DIFF
--- a/src/main/java/com/descope/literals/Routes.java
+++ b/src/main/java/com/descope/literals/Routes.java
@@ -263,6 +263,9 @@ public class Routes {
     public static final String MANAGEMENT_FETCH_OUTBOUND_APP_TENANT_TOKEN_LATEST =
         "/v1/mgmt/outbound/app/tenant/token/latest";
 
+    // License
+    public static final String MANAGEMENT_LICENSE_LINK = "/v1/mgmt/license";
+
     // Inbound
     public static final String MANAGEMENT_INBOUND_CREATE_APP = "/v1/mgmt/thirdparty/app/create";
     public static final String MANAGEMENT_INBOUND_UPDATE_APP = "/v1/mgmt/thirdparty/app/update";

--- a/src/main/java/com/descope/model/client/Client.java
+++ b/src/main/java/com/descope/model/client/Client.java
@@ -28,18 +28,29 @@ public class Client {
   // When set, sent along with every authentication request so that authentication methods whose
   // public access has been disabled can still be used. Never sent on management requests.
   private String authManagementKey;
+  // Fetched once when the management services are built and sent on every management request so
+  // the edge can apply the right rate limit bucket. Blank when the handshake failed.
+  private String rateLimitTier;
 
   // Keeps the pre-fgaCacheUri all-args constructor available to callers that use it positionally.
   public Client(String uri, String projectId, String managementKey, Map<String, String> headers,
       SdkInfo sdkInfo, Key providedKey, AtomicReference<Map<String, Key>> keys) {
-    this(uri, projectId, managementKey, headers, sdkInfo, providedKey, keys, null, null);
+    this(uri, projectId, managementKey, headers, sdkInfo, providedKey, keys, null, null, null);
   }
 
   // Keeps the pre-authManagementKey all-args constructor available to callers that use it
   // positionally.
   public Client(String uri, String projectId, String managementKey, Map<String, String> headers,
       SdkInfo sdkInfo, Key providedKey, AtomicReference<Map<String, Key>> keys, String fgaCacheUri) {
-    this(uri, projectId, managementKey, headers, sdkInfo, providedKey, keys, fgaCacheUri, null);
+    this(uri, projectId, managementKey, headers, sdkInfo, providedKey, keys, fgaCacheUri, null, null);
+  }
+
+  // Keeps the pre-rateLimitTier all-args constructor available to callers that use it positionally.
+  public Client(String uri, String projectId, String managementKey, Map<String, String> headers,
+      SdkInfo sdkInfo, Key providedKey, AtomicReference<Map<String, Key>> keys, String fgaCacheUri,
+      String authManagementKey) {
+    this(uri, projectId, managementKey, headers, sdkInfo, providedKey, keys, fgaCacheUri,
+        authManagementKey, null);
   }
 
   public Key getKey(String keyId) {

--- a/src/main/java/com/descope/model/license/LicenseResponse.java
+++ b/src/main/java/com/descope/model/license/LicenseResponse.java
@@ -1,0 +1,14 @@
+package com.descope.model.license;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LicenseResponse {
+  private String rateLimitTier;
+}

--- a/src/main/java/com/descope/proxy/impl/AbstractProxyImpl.java
+++ b/src/main/java/com/descope/proxy/impl/AbstractProxyImpl.java
@@ -195,6 +195,16 @@ abstract class AbstractProxyImpl {
     if (client != null && StringUtils.isNotBlank(client.getProjectId())) {
       req.addHeader("x-descope-project-id", client.getProjectId());
     }
+    if (client != null && StringUtils.isNotBlank(client.getRateLimitTier())
+        && StringUtils.isNotBlank(client.getManagementKey())
+        && isManagementRequest(req)) {
+      req.addHeader("x-descope-license", client.getRateLimitTier());
+    }
+  }
+
+  private boolean isManagementRequest(ClassicHttpRequest req) {
+    String path = req.getRequestUri();
+    return path != null && path.contains("/mgmt/");
   }
 
   @SneakyThrows

--- a/src/main/java/com/descope/sdk/mgmt/impl/ManagementServiceBuilder.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/ManagementServiceBuilder.java
@@ -9,7 +9,8 @@ import com.descope.utils.AuthUtils;
 import com.descope.utils.UriUtils;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.nio.charset.StandardCharsets;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -18,7 +19,6 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.util.Timeout;
 
@@ -28,7 +28,9 @@ public class ManagementServiceBuilder {
   // The handshake sits on the client construction path, so it gets a hard ceiling and no retries.
   // Going through ApiProxy instead would inherit its retry ladder, which can add over ten seconds
   // of sleeps to every DescopeClient construction when the endpoint is degraded.
-  private static final Timeout LICENSE_HANDSHAKE_TIMEOUT = Timeout.ofSeconds(5);
+  private static final long LICENSE_HANDSHAKE_TIMEOUT_SECONDS = 5;
+  private static final Timeout LICENSE_HANDSHAKE_TIMEOUT =
+      Timeout.ofSeconds(LICENSE_HANDSHAKE_TIMEOUT_SECONDS);
 
   public static ManagementServices buildServices(Client client) {
     fetchRateLimitTier(client);
@@ -71,8 +73,6 @@ public class ManagementServiceBuilder {
         .setConnectTimeout(LICENSE_HANDSHAKE_TIMEOUT)
         .setSocketTimeout(LICENSE_HANDSHAKE_TIMEOUT)
         .build();
-    // disableAutomaticRetries is deliberate: httpclient5 otherwise retries 429 and 503 on its own,
-    // which puts an unbounded-ish wait back on the construction path this timeout exists to bound.
     try (CloseableHttpClient httpClient = HttpClients.custom()
         .setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create()
             .setDefaultConnectionConfig(connectionConfig)
@@ -80,33 +80,53 @@ public class ManagementServiceBuilder {
         .setDefaultRequestConfig(requestConfig)
         .disableAutomaticRetries()
         .build()) {
-      String authHeader =
-          AuthUtils.getBearerHeader(client.getProjectId(), client.getManagementKey());
-      String body = httpClient.execute(
-          ClassicRequestBuilder.get(UriUtils.getUri(client.getUri(), MANAGEMENT_LICENSE_LINK))
-              .addHeader("Authorization", authHeader)
-              .addHeader("Content-Type", "application/json")
-              .build(),
-          response -> {
-            if (response.getCode() != 200 || response.getEntity() == null) {
-              log.warn("License handshake returned status {}", response.getCode());
-              return null;
-            }
-            return EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-          });
-      if (StringUtils.isBlank(body)) {
-        return;
+      // Apache's timeouts are per phase or inactivity period, so enforce the total deadline here.
+      FutureTask<LicenseResponse> handshake =
+          new FutureTask<>(() -> executeLicenseHandshake(httpClient, client));
+      Thread thread = new Thread(handshake, "descope-license-handshake");
+      thread.setDaemon(true);
+      thread.start();
+      LicenseResponse licenseResponse;
+      try {
+        licenseResponse =
+            handshake.get(LICENSE_HANDSHAKE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      } finally {
+        handshake.cancel(true);
       }
-      LicenseResponse licenseResponse = new ObjectMapper()
-          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-          .readValue(body, LicenseResponse.class);
       if (licenseResponse != null && StringUtils.isNotBlank(licenseResponse.getRateLimitTier())) {
         client.setRateLimitTier(licenseResponse.getRateLimitTier());
         log.debug("Rate limit tier fetched: {}", licenseResponse.getRateLimitTier());
       }
+    } catch (java.util.concurrent.TimeoutException e) {
+      log.warn("License handshake timed out after {} seconds, continuing without license header",
+          LICENSE_HANDSHAKE_TIMEOUT_SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      log.warn("License handshake interrupted, continuing without license header");
     } catch (Exception e) {
       log.warn("Failed to fetch rate limit tier, continuing without license header: {}",
           e.getMessage());
     }
+  }
+
+  private static LicenseResponse executeLicenseHandshake(CloseableHttpClient httpClient,
+      Client client)
+      throws Exception {
+    String authHeader =
+        AuthUtils.getBearerHeader(client.getProjectId(), client.getManagementKey());
+    return httpClient.execute(
+        ClassicRequestBuilder.get(UriUtils.getUri(client.getUri(), MANAGEMENT_LICENSE_LINK))
+            .addHeader("Authorization", authHeader)
+            .addHeader("Content-Type", "application/json")
+            .build(),
+        response -> {
+          if (response.getCode() != 200 || response.getEntity() == null) {
+            log.warn("License handshake returned status {}", response.getCode());
+            return null;
+          }
+          return new ObjectMapper()
+              .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+              .readValue(response.getEntity().getContent(), LicenseResponse.class);
+        });
   }
 }

--- a/src/main/java/com/descope/sdk/mgmt/impl/ManagementServiceBuilder.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/ManagementServiceBuilder.java
@@ -5,6 +5,7 @@ import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_LICENSE
 import com.descope.model.client.Client;
 import com.descope.model.license.LicenseResponse;
 import com.descope.model.mgmt.ManagementServices;
+import com.descope.utils.AuthUtils;
 import com.descope.utils.UriUtils;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,9 +13,11 @@ import java.nio.charset.StandardCharsets;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
 import org.apache.hc.core5.util.Timeout;
@@ -62,14 +65,23 @@ public class ManagementServiceBuilder {
         .setConnectionRequestTimeout(LICENSE_HANDSHAKE_TIMEOUT)
         .setResponseTimeout(LICENSE_HANDSHAKE_TIMEOUT)
         .build();
+    // RequestConfig bounds the connection lease and the response wait, but not Socket.connect,
+    // whose httpclient5 default is 3 minutes. Without this a dropped SYN stalls construction.
+    ConnectionConfig connectionConfig = ConnectionConfig.custom()
+        .setConnectTimeout(LICENSE_HANDSHAKE_TIMEOUT)
+        .setSocketTimeout(LICENSE_HANDSHAKE_TIMEOUT)
+        .build();
     // disableAutomaticRetries is deliberate: httpclient5 otherwise retries 429 and 503 on its own,
     // which puts an unbounded-ish wait back on the construction path this timeout exists to bound.
     try (CloseableHttpClient httpClient = HttpClients.custom()
+        .setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create()
+            .setDefaultConnectionConfig(connectionConfig)
+            .build())
         .setDefaultRequestConfig(requestConfig)
         .disableAutomaticRetries()
         .build()) {
       String authHeader =
-          String.format("Bearer %s:%s", client.getProjectId(), client.getManagementKey());
+          AuthUtils.getBearerHeader(client.getProjectId(), client.getManagementKey());
       String body = httpClient.execute(
           ClassicRequestBuilder.get(UriUtils.getUri(client.getUri(), MANAGEMENT_LICENSE_LINK))
               .addHeader("Authorization", authHeader)

--- a/src/main/java/com/descope/sdk/mgmt/impl/ManagementServiceBuilder.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/ManagementServiceBuilder.java
@@ -19,7 +19,9 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
+import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.util.Timeout;
 
 @Slf4j
@@ -29,6 +31,7 @@ public class ManagementServiceBuilder {
   // Going through ApiProxy instead would inherit its retry ladder, which can add over ten seconds
   // of sleeps to every DescopeClient construction when the endpoint is degraded.
   private static final long LICENSE_HANDSHAKE_TIMEOUT_SECONDS = 5;
+  private static final int LICENSE_RESPONSE_MAX_BYTES = 16 * 1024;
   private static final Timeout LICENSE_HANDSHAKE_TIMEOUT =
       Timeout.ofSeconds(LICENSE_HANDSHAKE_TIMEOUT_SECONDS);
 
@@ -90,6 +93,9 @@ public class ManagementServiceBuilder {
       try {
         licenseResponse =
             handshake.get(LICENSE_HANDSHAKE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      } catch (java.util.concurrent.TimeoutException | InterruptedException e) {
+        httpClient.close(CloseMode.IMMEDIATE);
+        throw e;
       } finally {
         handshake.cancel(true);
       }
@@ -126,7 +132,8 @@ public class ManagementServiceBuilder {
           }
           return new ObjectMapper()
               .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-              .readValue(response.getEntity().getContent(), LicenseResponse.class);
+              .readValue(EntityUtils.toByteArray(response.getEntity(),
+                  LICENSE_RESPONSE_MAX_BYTES), LicenseResponse.class);
         });
   }
 }

--- a/src/main/java/com/descope/sdk/mgmt/impl/ManagementServiceBuilder.java
+++ b/src/main/java/com/descope/sdk/mgmt/impl/ManagementServiceBuilder.java
@@ -1,12 +1,34 @@
 package com.descope.sdk.mgmt.impl;
 
-import com.descope.model.client.Client;
-import com.descope.model.mgmt.ManagementServices;
-import lombok.experimental.UtilityClass;
+import static com.descope.literals.Routes.ManagementEndPoints.MANAGEMENT_LICENSE_LINK;
 
+import com.descope.model.client.Client;
+import com.descope.model.license.LicenseResponse;
+import com.descope.model.mgmt.ManagementServices;
+import com.descope.utils.UriUtils;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
+import org.apache.hc.core5.util.Timeout;
+
+@Slf4j
 @UtilityClass
 public class ManagementServiceBuilder {
+  // The handshake sits on the client construction path, so it gets a hard ceiling and no retries.
+  // Going through ApiProxy instead would inherit its retry ladder, which can add over ten seconds
+  // of sleeps to every DescopeClient construction when the endpoint is degraded.
+  private static final Timeout LICENSE_HANDSHAKE_TIMEOUT = Timeout.ofSeconds(5);
+
   public static ManagementServices buildServices(Client client) {
+    fetchRateLimitTier(client);
     return ManagementServices.builder()
         .ssoService(new SsoServiceImpl(client))
         .jwtService(new JwtServiceImpl(client))
@@ -28,5 +50,51 @@ public class ManagementServiceBuilder {
         .inboundAppsService(new InboundAppsServiceImpl(client))
         .userCustomAttributesService(new UserCustomAttributesServiceImpl(client))
         .build();
+  }
+
+  // Best effort: a failure here only means management requests go out without the tier header,
+  // which the edge treats as the lowest bucket. It must never stop the SDK from being built.
+  static void fetchRateLimitTier(Client client) {
+    if (StringUtils.isBlank(client.getManagementKey())) {
+      return;
+    }
+    RequestConfig requestConfig = RequestConfig.custom()
+        .setConnectionRequestTimeout(LICENSE_HANDSHAKE_TIMEOUT)
+        .setResponseTimeout(LICENSE_HANDSHAKE_TIMEOUT)
+        .build();
+    // disableAutomaticRetries is deliberate: httpclient5 otherwise retries 429 and 503 on its own,
+    // which puts an unbounded-ish wait back on the construction path this timeout exists to bound.
+    try (CloseableHttpClient httpClient = HttpClients.custom()
+        .setDefaultRequestConfig(requestConfig)
+        .disableAutomaticRetries()
+        .build()) {
+      String authHeader =
+          String.format("Bearer %s:%s", client.getProjectId(), client.getManagementKey());
+      String body = httpClient.execute(
+          ClassicRequestBuilder.get(UriUtils.getUri(client.getUri(), MANAGEMENT_LICENSE_LINK))
+              .addHeader("Authorization", authHeader)
+              .addHeader("Content-Type", "application/json")
+              .build(),
+          response -> {
+            if (response.getCode() != 200 || response.getEntity() == null) {
+              log.warn("License handshake returned status {}", response.getCode());
+              return null;
+            }
+            return EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+          });
+      if (StringUtils.isBlank(body)) {
+        return;
+      }
+      LicenseResponse licenseResponse = new ObjectMapper()
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .readValue(body, LicenseResponse.class);
+      if (licenseResponse != null && StringUtils.isNotBlank(licenseResponse.getRateLimitTier())) {
+        client.setRateLimitTier(licenseResponse.getRateLimitTier());
+        log.debug("Rate limit tier fetched: {}", licenseResponse.getRateLimitTier());
+      }
+    } catch (Exception e) {
+      log.warn("Failed to fetch rate limit tier, continuing without license header: {}",
+          e.getMessage());
+    }
   }
 }

--- a/src/test/java/com/descope/proxy/impl/LicenseHeaderTest.java
+++ b/src/test/java/com/descope/proxy/impl/LicenseHeaderTest.java
@@ -1,0 +1,104 @@
+package com.descope.proxy.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import com.descope.model.client.Client;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class LicenseHeaderTest {
+
+  private static final String LICENSE_HEADER = "x-descope-license";
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  void testLicenseHeaderSentOnManagementRequest() throws IOException {
+    Header header = captureLicenseHeader(client("tier4", "mgmt-key"),
+        "http://localhost/v1/mgmt/user/create");
+    assertNotNull(header, "management request must carry the license header");
+    assertEquals("tier4", header.getValue());
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  void testLicenseHeaderNotSentOnNonManagementRequest() throws IOException {
+    Header header = captureLicenseHeader(client("tier4", "mgmt-key"),
+        "http://localhost/v1/auth/otp/verify");
+    assertNull(header, "auth requests must not carry the license header");
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  void testLicenseHeaderNotSentWhenTierMissing() throws IOException {
+    Header header = captureLicenseHeader(client("", "mgmt-key"),
+        "http://localhost/v1/mgmt/user/create");
+    assertNull(header, "a failed handshake must leave the header off entirely");
+  }
+
+  @Test
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  void testLicenseHeaderNotSentWithoutManagementKey() throws IOException {
+    Header header = captureLicenseHeader(client("tier4", ""),
+        "http://localhost/v1/mgmt/user/create");
+    assertNull(header, "without a management key there is no management session to tier");
+  }
+
+  // --- helpers ---
+
+  private Client client(String rateLimitTier, String managementKey) {
+    return Client.builder()
+        .uri("http://localhost")
+        .projectId("P123")
+        .managementKey(managementKey)
+        .rateLimitTier(rateLimitTier)
+        .keys(new AtomicReference<>(new java.util.HashMap<>()))
+        .build();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private Header captureLicenseHeader(Client client, String uri) throws IOException {
+    AtomicReference<ClassicHttpRequest> captured = new AtomicReference<>();
+    CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+    doAnswer(inv -> {
+      captured.set(inv.getArgument(0));
+      HttpClientResponseHandler handler = (HttpClientResponseHandler) inv.getArgument(1);
+      return handler.handleResponse(successResponse("{}"));
+    }).when(mockClient).execute(any(ClassicHttpRequest.class), any(HttpClientResponseHandler.class));
+
+    try (MockedStatic<HttpClients> mockedHttpClients = mockStatic(HttpClients.class)) {
+      mockedHttpClients.when(HttpClients::createDefault).thenReturn(mockClient);
+      ApiProxyImpl proxy = new ApiProxyImpl(() -> "Bearer P123:mgmt-key", client);
+      proxy.get(URI.create(uri), Map.class);
+    }
+    return captured.get().getFirstHeader(LICENSE_HEADER);
+  }
+
+  private ClassicHttpResponse successResponse(String body) throws IOException {
+    ClassicHttpResponse response = mock(ClassicHttpResponse.class);
+    org.mockito.Mockito.when(response.getCode()).thenReturn(200);
+    HttpEntity entity = mock(HttpEntity.class);
+    org.mockito.Mockito.when(entity.getContent())
+        .thenReturn(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+    org.mockito.Mockito.when(response.getEntity()).thenReturn(entity);
+    return response;
+  }
+}

--- a/src/test/java/com/descope/sdk/mgmt/impl/LicenseHandshakeTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/LicenseHandshakeTest.java
@@ -11,9 +11,11 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 class LicenseHandshakeTest {
 
@@ -71,6 +73,26 @@ class LicenseHandshakeTest {
     } finally {
       server.stop(0);
     }
+  }
+
+  // RFC 5737 TEST-NET-1 is guaranteed unrouted, so the SYN is dropped rather than refused. This
+  // guards the TCP connect phase, which RequestConfig alone does not bound: httpclient5 defaults
+  // ConnectionConfig.connectTimeout to 3 minutes.
+  @Test
+  @Timeout(value = 25, unit = TimeUnit.SECONDS)
+  void testUnreachableEndpointDoesNotBlockOnTcpConnect() {
+    Client client = Client.builder()
+        .uri("http://192.0.2.1:81")
+        .projectId("P123")
+        .managementKey("mgmt-key")
+        .keys(new AtomicReference<>(new HashMap<>()))
+        .build();
+    long start = System.nanoTime();
+    ManagementServiceBuilder.fetchRateLimitTier(client);
+    long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+    assertNull(client.getRateLimitTier());
+    assertTrue(elapsedMs < 9_000,
+        "TCP connect must be bounded by the handshake timeout, took " + elapsedMs + "ms");
   }
 
   @Test

--- a/src/test/java/com/descope/sdk/mgmt/impl/LicenseHandshakeTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/LicenseHandshakeTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -88,6 +89,8 @@ class LicenseHandshakeTest {
       assertTrue(elapsedMs < 9_000,
           "slow response body must not extend the total handshake timeout, took " + elapsedMs
               + "ms");
+      assertTrue(waitForHandshakeThreadToStop(),
+          "timed-out handshake must abort its background thread");
     } finally {
       server.stop(0);
     }
@@ -123,6 +126,20 @@ class LicenseHandshakeTest {
       assertNull(client.getRateLimitTier());
       assertEquals(0, calls.get(),
           "no management key means no handshake request at all");
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void testOversizedResponseLeavesTierUnset() throws IOException {
+    String body = "{\"rateLimitTier\":\"tier4\",\"padding\":\""
+        + StringUtils.repeat('x', 16 * 1024) + "\"}";
+    HttpServer server = serverReturning(200, body, null);
+    try {
+      Client client = client(server, "mgmt-key");
+      ManagementServiceBuilder.fetchRateLimitTier(client);
+      assertNull(client.getRateLimitTier());
     } finally {
       server.stop(0);
     }
@@ -191,5 +208,23 @@ class LicenseHandshakeTest {
     });
     server.start();
     return server;
+  }
+
+  private boolean waitForHandshakeThreadToStop() {
+    for (int i = 0; i < 100; i++) {
+      boolean running = Thread.getAllStackTraces().keySet().stream()
+          .anyMatch(thread -> thread.isAlive()
+              && thread.getName().equals("descope-license-handshake"));
+      if (!running) {
+        return true;
+      }
+      try {
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return false;
+      }
+    }
+    return false;
   }
 }

--- a/src/test/java/com/descope/sdk/mgmt/impl/LicenseHandshakeTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/LicenseHandshakeTest.java
@@ -1,0 +1,134 @@
+package com.descope.sdk.mgmt.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.descope.model.client.Client;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class LicenseHandshakeTest {
+
+  @Test
+  void testTierIsCachedFromResponse() throws IOException {
+    HttpServer server = serverReturning(200, "{\"rateLimitTier\":\"tier4\"}", null);
+    try {
+      Client client = client(server, "mgmt-key");
+      ManagementServiceBuilder.fetchRateLimitTier(client);
+      assertEquals("tier4", client.getRateLimitTier());
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void testUnknownResponseFieldsAreTolerated() throws IOException {
+    HttpServer server =
+        serverReturning(200, "{\"rateLimitTier\":\"tier3\",\"somethingNew\":\"x\"}", null);
+    try {
+      Client client = client(server, "mgmt-key");
+      ManagementServiceBuilder.fetchRateLimitTier(client);
+      assertEquals("tier3", client.getRateLimitTier());
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void testErrorResponseLeavesTierUnsetAndIsNotRetried() throws IOException {
+    AtomicInteger calls = new AtomicInteger(0);
+    HttpServer server = serverReturning(503, "{}", calls);
+    try {
+      Client client = client(server, "mgmt-key");
+      ManagementServiceBuilder.fetchRateLimitTier(client);
+      assertNull(client.getRateLimitTier(), "a failed handshake must not set a tier");
+      assertEquals(1, calls.get(),
+          "the handshake must not inherit the proxy retry ladder");
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void testSlowEndpointDoesNotBlockBeyondTimeout() throws IOException {
+    HttpServer server = slowServer();
+    try {
+      Client client = client(server, "mgmt-key");
+      long start = System.nanoTime();
+      ManagementServiceBuilder.fetchRateLimitTier(client);
+      long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+      assertNull(client.getRateLimitTier());
+      assertTrue(elapsedMs < 9_000,
+          "handshake must give up on its own timeout, took " + elapsedMs + "ms");
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void testNoManagementKeySkipsHandshakeEntirely() throws IOException {
+    AtomicInteger calls = new AtomicInteger(0);
+    HttpServer server = serverReturning(200, "{\"rateLimitTier\":\"tier4\"}", calls);
+    try {
+      Client client = client(server, "");
+      ManagementServiceBuilder.fetchRateLimitTier(client);
+      assertNull(client.getRateLimitTier());
+      assertEquals(0, calls.get(),
+          "no management key means no handshake request at all");
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  // --- helpers ---
+
+  private Client client(HttpServer server, String managementKey) {
+    return Client.builder()
+        .uri("http://localhost:" + server.getAddress().getPort())
+        .projectId("P123")
+        .managementKey(managementKey)
+        .keys(new AtomicReference<>(new HashMap<>()))
+        .build();
+  }
+
+  private HttpServer serverReturning(int status, String body, AtomicInteger calls)
+      throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/v1/mgmt/license", exchange -> {
+      if (calls != null) {
+        calls.incrementAndGet();
+      }
+      byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+      exchange.sendResponseHeaders(status, payload.length);
+      try (OutputStream os = exchange.getResponseBody()) {
+        os.write(payload);
+      }
+    });
+    server.start();
+    return server;
+  }
+
+  private HttpServer slowServer() throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/v1/mgmt/license", exchange -> {
+      // Comfortably past the 5s handshake timeout without making the suite wait much longer.
+      try {
+        Thread.sleep(8_000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      exchange.sendResponseHeaders(200, 0);
+      exchange.close();
+    });
+    server.start();
+    return server;
+  }
+}

--- a/src/test/java/com/descope/sdk/mgmt/impl/LicenseHandshakeTest.java
+++ b/src/test/java/com/descope/sdk/mgmt/impl/LicenseHandshakeTest.java
@@ -75,6 +75,24 @@ class LicenseHandshakeTest {
     }
   }
 
+  @Test
+  @Timeout(value = 12, unit = TimeUnit.SECONDS)
+  void testSlowDripResponseDoesNotExtendTotalTimeout() throws IOException {
+    HttpServer server = slowDripServer();
+    try {
+      Client client = client(server, "mgmt-key");
+      long start = System.nanoTime();
+      ManagementServiceBuilder.fetchRateLimitTier(client);
+      long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+      assertNull(client.getRateLimitTier());
+      assertTrue(elapsedMs < 9_000,
+          "slow response body must not extend the total handshake timeout, took " + elapsedMs
+              + "ms");
+    } finally {
+      server.stop(0);
+    }
+  }
+
   // RFC 5737 TEST-NET-1 is guaranteed unrouted, so the SYN is dropped rather than refused. This
   // guards the TCP connect phase, which RequestConfig alone does not bound: httpclient5 defaults
   // ConnectionConfig.connectTimeout to 3 minutes.
@@ -149,6 +167,27 @@ class LicenseHandshakeTest {
       }
       exchange.sendResponseHeaders(200, 0);
       exchange.close();
+    });
+    server.start();
+    return server;
+  }
+
+  private HttpServer slowDripServer() throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/v1/mgmt/license", exchange -> {
+      exchange.sendResponseHeaders(200, 0);
+      try (OutputStream os = exchange.getResponseBody()) {
+        // A socket timeout is inactivity-based; these writes keep resetting it.
+        for (int i = 0; i < 10; i++) {
+          os.write(' ');
+          os.flush();
+          Thread.sleep(1_000);
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } catch (IOException ignored) {
+        // The client closes the connection when its total deadline expires.
+      }
     });
     server.start();
     return server;


### PR DESCRIPTION
## Related Issues
Resolves https://github.com/descope/etc/issues/17694

## Related PRs
| repo | PR |
| ---- | -- |
| backend | https://github.com/descope/backend/pull/2310 |

## Description
The Java SDK did not send `x-descope-license`, so management requests were assigned the lowest rate-limit bucket regardless of the company's plan. This PR brings Java in line with the other server SDKs:

- Fetch `rateLimitTier` once from `GET /v1/mgmt/license` during client construction.
- Cache it on `Client` while preserving the existing positional constructors.
- Add `x-descope-license` to management requests only.
- Treat handshake failure as non-fatal and continue without the header.

## Diff shape
The production diff is limited to the endpoint/model, cached client field, management-only header injection, and the handshake. The two new test files cover those behaviors; there are no unrelated refactors or formatting changes.

The handshake is synchronous so the first management request can carry the tier, matching Go's construction-time behavior. Apache HttpClient's configured timeouts are phase/inactivity limits rather than a total request deadline, so the dedicated client also uses a five-second `FutureTask` boundary and force-closes the exchange on timeout. Automatic retries are disabled and the response body is capped at 16 KB.

## Testing
- `mvn -Dtest=LicenseHandshakeTest,LicenseHeaderTest test` — 12 tests pass
- `mvn checkstyle:check` — 0 violations

## Must
- [x] Tests
- [ ] Documentation (if applicable)
